### PR TITLE
ファイル名のtypoを修正

### DIFF
--- a/app/assets/javascripts/components.js
+++ b/app/assets/javascripts/components.js
@@ -3,4 +3,4 @@
 
 window.React = require('react');
 window.ReactDOM = require('react-dom');
-window.Widgets = require('./components/Widgets.jsx');
+window.Widgets = require('./components/widgets.jsx');


### PR DESCRIPTION
## 事象

以下のエラーが発生し、herokuにデプロイができなくなっていた
```
remote:        Running: rake assets:precompile
remote:        D, [2016-10-20T14:43:06.416370 #434] DEBUG -- : Browserify: /tmp/build_4489abd4d29bb410e37c64ab6b230146/node_modules/.bin/browserify --transform reactify --list -o "/tmp/build_4489abd4d29bb410e37c64ab6b230146/tmp/cache/browserify-rails/output20161020-434-12622yw" -
remote:        rake aborted!
remote:        BrowserifyRails::BrowserifyError: Error while running `/tmp/build_4489abd4d29bb410e37c64ab6b230146/node_modules/.bin/browserify --transform reactify --list -o "/tmp/build_4489abd4d29bb410e37c64ab6b230146/tmp/cache/browserify-rails/output20161020-434-12622yw" -`:
remote:        events.js:154
remote:        throw er; // Unhandled 'error' event
remote:        ^
remote:        Error: Cannot find module './components/Widgets.jsx' from '/tmp/build_4489abd4d29bb410e37c64ab6b230146/app/assets/javascripts'
```
## 対応内容

ファイル名`Widgets.jsx`を`widget.jsx`に修正しました

