### PR TITLE
開発に使うgemを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,8 @@ group :development do
   gem 'spring-watcher-listen', '~> 2.0.0'
   gem 'guard-rubocop'
   gem 'rubocop', require: false
+  gem 'better_errors'
+  gem 'binding_of_caller'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,12 @@ GEM
     babel-transpiler (0.7.0)
       babel-source (>= 4.0, < 6)
       execjs (~> 2.0)
+    better_errors (2.1.1)
+      coderay (>= 1.0.0)
+      erubis (>= 2.6.6)
+      rack (>= 0.9.0)
+    binding_of_caller (0.7.2)
+      debug_inspector (>= 0.0.1)
     browserify-rails (3.2.0)
       addressable (>= 2.4.0)
       railties (>= 4.0.0, < 5.1)
@@ -61,6 +67,7 @@ GEM
     coffee-script-source (1.10.0)
     concurrent-ruby (1.0.2)
     connection_pool (2.2.0)
+    debug_inspector (0.0.2)
     diff-lcs (1.2.5)
     erubis (2.7.0)
     execjs (2.7.0)
@@ -246,6 +253,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  better_errors
+  binding_of_caller
   browserify-rails
   byebug
   coffee-rails


### PR DESCRIPTION
## 対応内容

以下のgemを追加しました
- `better_errors`
- `binding_of_caller`
## 対応理由

開発で使うため
