### PR TITLE
シーズンのモデルを追加

### DIFF
--- a/app/models/anime.rb
+++ b/app/models/anime.rb
@@ -1,3 +1,5 @@
 class Anime < ApplicationRecord
+  has_many :seasons
+
   validates :title, presence: true
 end

--- a/app/models/season.rb
+++ b/app/models/season.rb
@@ -1,0 +1,5 @@
+class Season < ApplicationRecord
+  belongs_to :anime
+
+  validates :name, presence: true
+end

--- a/db/migrate/20161022211023_create_seasons.rb
+++ b/db/migrate/20161022211023_create_seasons.rb
@@ -1,0 +1,12 @@
+class CreateSeasons < ActiveRecord::Migration[5.0]
+  def change
+    create_table :seasons do |t|
+      t.integer :anime_id, null: false
+      t.string :name, null: false
+      t.date :start_on
+      t.date :end_on
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161022192806) do
+ActiveRecord::Schema.define(version: 20161022211023) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,15 @@ ActiveRecord::Schema.define(version: 20161022192806) do
     t.string   "summary"
     t.string   "wiki_url"
     t.string   "picture"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "seasons", force: :cascade do |t|
+    t.integer  "anime_id",   null: false
+    t.string   "name",       null: false
+    t.date     "start_on"
+    t.date     "end_on"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/spec/factories/seasons.rb
+++ b/spec/factories/seasons.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :season do
+    anime
+    sequence(:name) { |n| "アニメタイトル#{n}" }
+    start_on { Time.zone.today - 10.days }
+    end_on { [Time.zone.today, nil].sample }
+  end
+end

--- a/spec/factories/seasons.rb
+++ b/spec/factories/seasons.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :season do
     anime
-    sequence(:name) { |n| "アニメタイトル#{n}" }
+    sequence(:name) { |n| "シーズン名#{n}" }
     start_on { Time.zone.today - 10.days }
     end_on { [Time.zone.today, nil].sample }
   end

--- a/spec/models/anime_spec.rb
+++ b/spec/models/anime_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Anime, type: :model do
+  it { is_expected.to have_many(:seasons) }
+
   describe 'バリデーション' do
     it { is_expected.to validate_presence_of(:title) }
   end

--- a/spec/models/season_spec.rb
+++ b/spec/models/season_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe Season, type: :model do
+  it { is_expected.to belong_to(:anime) }
+
+  describe 'バリデーション' do
+    it { is_expected.to validate_presence_of(:name) }
+  end
+end


### PR DESCRIPTION
## 対応内容

シーズンのモデルを追加しました

## 対応理由

アニメの1期、2期の情報を保存するため