### PR TITLE
FactoryGirlのファイル数によりテストが失敗する

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -60,4 +60,8 @@ RSpec.configure do |config|
       DatabaseRewinder.clean_all
     end
   end
+
+  config.after :each do
+    DatabaseRewinder.clean_all
+  end
 end


### PR DESCRIPTION
## 事象

FactoryGirlのファイルを追加するたびに、データのレコードが余分に追加されているため、
テスト結果の件数がexpectと合致しない

## 対応内容

テスト実行後のたびに、データベース内のデータをクリアするように修正しました


