### PR TITLE
ajaxのレスポンスを待つfeature specのhelperメソッドを追加

### DIFF
--- a/spec/features/welcome_spec.rb
+++ b/spec/features/welcome_spec.rb
@@ -8,6 +8,7 @@ feature 'トップページ', js: true do
   end
 
   scenario 'アニメ一覧が表示されること' do
+    wait_for_ajax
     expect(page).to have_content anime.title
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -50,6 +50,7 @@ RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
   config.include RSpec::JsonMatcher
   config.include ActiveJob::TestHelper
+  config.include FeatureSpecHelper, type: :feature
 
   config.before :suite do
     I18n.locale = :ja

--- a/spec/support/feature_spec_helper.rb
+++ b/spec/support/feature_spec_helper.rb
@@ -1,0 +1,13 @@
+module FeatureSpecHelper
+  def wait_for_ajax
+    Timeout.timeout(Capybara.default_max_wait_time) do
+      loop until finished_all_ajax_requests?
+    end 
+  end
+
+  private
+
+  def finished_all_ajax_requests?
+    page.evaluate_script('jQuery.active').zero?
+  end
+end

--- a/spec/support/feature_spec_helper.rb
+++ b/spec/support/feature_spec_helper.rb
@@ -2,7 +2,7 @@ module FeatureSpecHelper
   def wait_for_ajax
     Timeout.timeout(Capybara.default_max_wait_time) do
       loop until finished_all_ajax_requests?
-    end 
+    end
   end
 
   private


### PR DESCRIPTION
## 対応内容

ajaxのレスポンスを待つfeature specのhelperメソッド`wait_for_ajax`を追加しました。

## 対応理由

時々、features specのテストが落ちていました。
ajaxで返ってくるレスポンスの遅延によって、失敗していると予想。
回避策として、ajaxのレスポンスを待つようにします。
