### PR TITLE
Autodocを追加し、設定

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ node_modules/*
 
 # Ignore coverage files
 coverage/*
+
+# Ignore document files
+doc/*

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ group :development, :test do
 end
 
 group :test do
+  gem 'autodoc'
   gem 'rspec-rails'
   gem 'rspec-collection_matchers'
   gem 'shoulda-matchers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,10 @@ GEM
     addressable (2.4.0)
     arel (7.1.4)
     ast (2.3.0)
+    autodoc (0.6.0)
+      actionpack
+      activesupport (>= 3.0.0)
+      rspec
     awesome_print (1.7.0)
     babel-source (5.8.35)
     babel-transpiler (0.7.0)
@@ -221,6 +225,10 @@ GEM
       railties (>= 3.2)
       tilt
     ref (2.0.0)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
     rspec-collection_matchers (1.1.2)
       rspec-expectations (>= 2.99.0.beta1)
     rspec-core (3.5.4)
@@ -307,6 +315,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  autodoc
   better_errors
   binding_of_caller
   brakeman

--- a/spec/autodoc/templates/document.md.erb
+++ b/spec/autodoc/templates/document.md.erb
@@ -1,0 +1,16 @@
+## <%= title %>
+<%= example.full_description %>
+<%= parameters_section %>
+### Example
+
+#### Request
+```
+<%= method %> <%= request.path %><%= request_query %> <%= request_http_version %>
+<%= request_header %><%= request_body_section %>
+```
+
+#### Response
+```
+<%= response_http_version %> <%= response.status %>
+<%= response_header %><%= response_body_section %>
+```

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -64,4 +64,17 @@ RSpec.configure do |config|
   config.after :each do
     DatabaseRewinder.clean_all
   end
+
+  Autodoc.configuration.template =
+    File.read(
+      File.expand_path('../autodoc/templates/document.md.erb', __FILE__)
+    )
+  Autodoc.configuration.suppressed_request_header =
+    %w(Accept Content-Length Host)
+  Autodoc.configuration.suppressed_response_header =
+    %w(
+      Cache-Control Content-Length ETag
+      X-Content-Type-Options X-Frame-Options X-Request-Id
+      X-Runtime X-XSS-Protection
+    )
 end

--- a/spec/requests/animes_spec.rb
+++ b/spec/requests/animes_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-describe 'GET /api/animes' do
+describe 'GET /api/animes', autodoc: true do
   let!(:anime1) { create(:anime) }
   let!(:anime2) { create(:anime) }
 


### PR DESCRIPTION
## 対応内容

- Gemfileにautodocを追加しました
- `spec/rails_helper.rb`にテスト実行時に出力できるように設定しました

以下でドキュメント出力します。
```
AUTODOC=1 bundle exec rspec
```

## 対応理由

APIのリクエストとレスポンスの情報を自動でドキュメントにするため