### PR TITLE
rubocopの設定を変更

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,3 +21,7 @@ Documentation:
 Metrics/AbcSize:
   Enabled: true
   Max: 20
+
+# ModuleとClassの形式をcompactに設定
+Style/ClassAndModuleChildren:
+  EnforcedStyle: compact

--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -1,4 +1,2 @@
-module ApplicationCable
-  class Channel < ActionCable::Channel::Base
-  end
+class ApplicationCable::Channel < ActionCable::Channel::Base
 end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,4 +1,2 @@
-module ApplicationCable
-  class Connection < ActionCable::Connection::Base
-  end
+class ApplicationCable::Connection < ActionCable::Connection::Base
 end

--- a/app/controllers/admin/top_controller.rb
+++ b/app/controllers/admin/top_controller.rb
@@ -1,6 +1,4 @@
-module Admin
-  class TopController < ApplicationController
-    def index
-    end
+class Admin::TopController < ApplicationController
+  def index
   end
 end

--- a/app/controllers/api/animes_controller.rb
+++ b/app/controllers/api/animes_controller.rb
@@ -1,7 +1,5 @@
-module Api
-  class AnimesController < ApplicationController
-    def index
-      @animes = Anime.all
-    end
+class Api::AnimesController < ApplicationController
+  def index
+    @animes = Anime.all
   end
 end


### PR DESCRIPTION
## 対応内容

rubocopの`Style/ClassAndModuleChildren`の設定をcompactに変更しました。
設定変更後のrubocopに沿った修正を行いました。

## 対応理由

設定が`nested`の場合、モジュールがあるとインデントが深くなる可能性があるため