### PR TITLE
管理画面にメニューを追加

### DIFF
--- a/app/controllers/admin/animes_controller.rb
+++ b/app/controllers/admin/animes_controller.rb
@@ -1,4 +1,4 @@
-class Admin::AnimesController < ApplicationController
+class Admin::AnimesController < Admin::BaseController
   before_action :set_anime, only: [:show, :edit, :update, :destroy]
 
   def index

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,0 +1,3 @@
+class Admin::BaseController < ApplicationController
+  layout 'admin'
+end

--- a/app/controllers/admin/top_controller.rb
+++ b/app/controllers/admin/top_controller.rb
@@ -1,4 +1,4 @@
-class Admin::TopController < ApplicationController
+class Admin::TopController < Admin::BaseController
   def index
   end
 end

--- a/app/views/application/_admin_menu.html.slim
+++ b/app/views/application/_admin_menu.html.slim
@@ -1,0 +1,1 @@
+= link_to 'アニメ', admin_animes_path

--- a/app/views/layouts/admin.html.slim
+++ b/app/views/layouts/admin.html.slim
@@ -1,0 +1,14 @@
+doctype html
+html
+head
+  title Anime Music
+  = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': true
+  = stylesheet_link_tag 'https://maxcdn.bootstrapcdn.com/bootstrap/latest/css/bootstrap.min.css'
+  = stylesheet_link_tag 'https://maxcdn.bootstrapcdn.com/bootstrap/latest/css/bootstrap-theme.min.css'
+  = javascript_include_tag 'application', 'data-turbolinks-track': true
+  = csrf_meta_tags
+
+.container
+  .row
+    = render 'admin_menu'
+    = yield


### PR DESCRIPTION
## 対応内容

管理画面用のレイアウトを追加し、管理画面の場合は管理メニューを表示するようにしました

## 対応理由

管理画面にメニューがないと不便なため
