### PR TITLE
phantomjsのバージョンを固定

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ group :test do
   gem 'rspec-json_matcher', require: false
   gem 'selenium-webdriver'
   gem 'rack_session_access'
-  gem 'phantomjs'
+  gem 'phantomjs', '2.1.1.0'
   gem 'poltergeist'
   gem 'capybara'
   gem 'capybara-email'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -344,7 +344,7 @@ DEPENDENCIES
   jquery-rails
   listen (~> 3.0.5)
   pg (~> 0.18)
-  phantomjs
+  phantomjs (= 2.1.1.0)
   poltergeist
   pry-byebug
   pry-rails


### PR DESCRIPTION
## 事象

```
Phantomjs does not appear to be installed in /root/.phantomjs/2.1.1/x86_64-linux/bin/phantomjs, installing!
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100   333    0   333    0     0   7283      0 --:--:-- --:--:-- --:--:--  7283
bunzip2: phantomjs-2.1.1-linux-x86_64.tar.bz2 is not a bzip2 file.
tar: phantomjs-2.1.1-linux-x86_64.tar: Cannot open: No such file or directory
tar: Error is not recoverable: exiting now
Phantomjs does not appear to be installed in /root/.phantomjs/2.1.1/x86_64-linux/bin/phantomjs, installing!
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 22.3M  100 22.3M    0     0  82.8M      0 --:--:-- --:--:-- --:--:-- 82.8M

Successfully installed phantomjs. Yay!
Removed temporarily downloaded files.
F........................

Failures:

  1) トップページ アニメ一覧が表示されること
     Failure/Error: Capybara::Poltergeist::Driver.new(app, phantomjs: Phantomjs.path)

     TypeError:
       no implicit conversion of nil into String
     # /pipeline/cache/bundle-install/ruby/2.3.0/gems/phantomjs-2.1.1.0/lib/phantomjs/platform.rb:72:in `block in install!'
     # /pipeline/cache/bundle-install/ruby/2.3.0/gems/phantomjs-2.1.1.0/lib/phantomjs/platform.rb:53:in `chdir'
     # /pipeline/cache/bundle-install/ruby/2.3.0/gems/phantomjs-2.1.1.0/lib/phantomjs/platform.rb:53:in `install!'
     # /pipeline/cache/bundle-install/ruby/2.3.0/gems/phantomjs-2.1.1.0/lib/phantomjs/platform.rb:86:in `ensure_installed!'
     # /pipeline/cache/bundle-install/ruby/2.3.0/gems/phantomjs-2.1.1.0/lib/phantomjs.rb:30:in `platform'
     # /pipeline/cache/bundle-install/ruby/2.3.0/gems/phantomjs-2.1.1.0/lib/phantomjs.rb:25:in `path'
     # ./spec/rails_helper.rb:27:in `block in <top (required)>'
     # /pipeline/cache/bundle-install/ruby/2.3.0/gems/capybara-2.10.1/lib/capybara/session.rb:85:in `driver'
     # /pipeline/cache/bundle-install/ruby/2.3.0/gems/capybara-2.10.1/lib/capybara/session.rb:71:in `initialize'
     # /pipeline/cache/bundle-install/ruby/2.3.0/gems/capybara-2.10.1/lib/capybara.rb:324:in `new'
     # /pipeline/cache/bundle-install/ruby/2.3.0/gems/capybara-2.10.1/lib/capybara.rb:324:in `current_session'
     # /pipeline/cache/bundle-install/ruby/2.3.0/gems/capybara-2.10.1/lib/capybara/dsl.rb:47:in `page'
     # /pipeline/cache/bundle-install/ruby/2.3.0/gems/capybara-2.10.1/lib/capybara/dsl.rb:52:in `block (2 levels) in <module:DSL>'
     # ./spec/features/welcome_spec.rb:7:in `block (2 levels) in <top (required)>'
```

## 再現方法

CI上でのテストにて。タイミングは、ランダム。

## 対応内容

一旦、phantomJSのバージョンを固定しました。
この状態で、正常に動作するかはしばらく様子をみます。

## 対応理由

CI上のphantomJSとのバージョンが合致しないために、features specのテストで落ちる
