### PR TITLE
jest-cli更新時のwarningを解消

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "jest"
   },
   "jest": {
-    "scriptPreprocessor": "./app/assets/javascripts/jest-script-preprocessor",
+    "transform": "./app/assets/javascripts/jest-script-preprocessor",
     "automock": true,
     "unmockedModulePathPatterns": [
       "react",


### PR DESCRIPTION
## 事象

#95 の`jest-cli`アップグレードに伴い、
以下のコマンドで、warningが発生しました。
```
# jest
```

```
● The settings `scriptPreprocessor` and `preprocessorIgnorePatterns` were replaced by `transform` and `transformIgnorePatterns` which support multiple preprocessors.

  Jest now treats your current settings as: 

    "transform": {".*": "./app/assets/javascripts/jest-script-preprocessor"}

  Please update your configuration.

  Jest changed the default configuration for tests.

  Configuration Documentation: https://facebook.github.io/jest/docs/configuration.html
  Jest Issue Tracker: https://github.com/facebook/jest/issues
```

## 対応内容

説明通り、package.jsonの`scriptPreprocessor`を`transform`にしました
