### PR TITLE
phantomjsのエラー

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ group :test do
   gem 'selenium-webdriver'
   gem 'rack_session_access'
   gem 'poltergeist'
-  gem 'phantomjs', require: 'phantomjs/poltergeist'
+  gem 'phantomjs'
   gem 'capybara'
   gem 'capybara-email'
   gem 'capybara-screenshot'


### PR DESCRIPTION
## 事象

以下のエラーがwerckerで発生していました。
greenkeeperのbotがPR作成になかなか成功しないので、修正を試みました。

```
Bundler::GemRequireError: There was an error while trying to load the gem 'phantomjs/poltergeist'.
Gem Load Error is: no implicit conversion of nil into String
Backtrace for gem load error is:
/usr/local/lib/ruby/2.3.0/fileutils.rb:1583:in `path'
/usr/local/lib/ruby/2.3.0/fileutils.rb:1583:in `fu_each_src_dest0'
/usr/local/lib/ruby/2.3.0/fileutils.rb:1569:in `fu_each_src_dest'
/usr/local/lib/ruby/2.3.0/fileutils.rb:517:in `mv'
/pipeline/cache/bundle-install/ruby/2.3.0/gems/phantomjs-2.1.1.0/lib/phantomjs/platform.rb:72:in `block in install!'
/pipeline/cache/bundle-install/ruby/2.3.0/gems/phantomjs-2.1.1.0/lib/phantomjs/platform.rb:53:in `chdir'
/pipeline/cache/bundle-install/ruby/2.3.0/gems/phantomjs-2.1.1.0/lib/phantomjs/platform.rb:53:in `install!'
/pipeline/cache/bundle-install/ruby/2.3.0/gems/phantomjs-2.1.1.0/lib/phantomjs/platform.rb:86:in `ensure_installed!'
/pipeline/cache/bundle-install/ruby/2.3.0/gems/phantomjs-2.1.1.0/lib/phantomjs.rb:30:in `platform'
/pipeline/cache/bundle-install/ruby/2.3.0/gems/phantomjs-2.1.1.0/lib/phantomjs.rb:25:in `path'
/pipeline/cache/bundle-install/ruby/2.3.0/gems/phantomjs-2.1.1.0/lib/phantomjs/poltergeist.rb:10:in `<top (required)>'
/usr/local/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/runtime.rb:91:in `require'
/usr/local/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/runtime.rb:91:in `block (2 levels) in require'
/usr/local/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/runtime.rb:86:in `each'
/usr/local/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/runtime.rb:86:in `block in require'
/usr/local/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/runtime.rb:75:in `each'
/usr/local/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/runtime.rb:75:in `require'
/usr/local/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler.rb:106:in `require'
/pipeline/source/config/application.rb:7:in `<top (required)>'
/pipeline/source/Rakefile:4:in `require_relative'
/pipeline/source/Rakefile:4:in `<top (required)>'
/pipeline/cache/bundle-install/ruby/2.3.0/gems/rake-11.3.0/lib/rake/rake_module.rb:28:in `load'
/pipeline/cache/bundle-install/ruby/2.3.0/gems/rake-11.3.0/lib/rake/rake_module.rb:28:in `load_rakefile'
/pipeline/cache/bundle-install/ruby/2.3.0/gems/rake-11.3.0/lib/rake/application.rb:686:in `raw_load_rakefile'
/pipeline/cache/bundle-install/ruby/2.3.0/gems/rake-11.3.0/lib/rake/application.rb:96:in `block in load_rakefile'
/pipeline/cache/bundle-install/ruby/2.3.0/gems/rake-11.3.0/lib/rake/application.rb:178:in `standard_exception_handling'
/pipeline/cache/bundle-install/ruby/2.3.0/gems/rake-11.3.0/lib/rake/application.rb:95:in `load_rakefile'
/pipeline/cache/bundle-install/ruby/2.3.0/gems/rake-11.3.0/lib/rake/application.rb:79:in `block in run'
/pipeline/cache/bundle-install/ruby/2.3.0/gems/rake-11.3.0/lib/rake/application.rb:178:in `standard_exception_handling'
/pipeline/cache/bundle-install/ruby/2.3.0/gems/rake-11.3.0/lib/rake/application.rb:77:in `run'
/pipeline/cache/bundle-install/ruby/2.3.0/gems/rake-11.3.0/exe/rake:27:in `<top (required)>'
/pipeline/cache/bundle-install/ruby/2.3.0/bin/rake:22:in `load'
/pipeline/cache/bundle-install/ruby/2.3.0/bin/rake:22:in `<top (required)>'
/usr/local/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/cli/exec.rb:74:in `load'
/usr/local/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/cli/exec.rb:74:in `kernel_load'
/usr/local/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/cli/exec.rb:27:in `run'
/usr/local/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/cli.rb:332:in `exec'
/usr/local/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/usr/local/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
/usr/local/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/vendor/thor/lib/thor.rb:359:in `dispatch'
/usr/local/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/cli.rb:20:in `dispatch'
/usr/local/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/vendor/thor/lib/thor/base.rb:440:in `start'
/usr/local/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/cli.rb:11:in `start'
/usr/local/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/exe/bundle:34:in `block in <top (required)>'
/usr/local/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/friendly_errors.rb:100:in `with_friendly_errors'
/usr/local/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/exe/bundle:26:in `<top (required)>'
/usr/local/bin/bundle:22:in `load'
/usr/local/bin/bundle:22:in `<main>'
・・・
```

## 対応内容

phantomjsのgemで指定している`require`を削除しました