### PR TITLE
activeリンクの範囲を変更

### DIFF
--- a/app/assets/javascripts/components/admin/actors/admin_actors_page.jsx
+++ b/app/assets/javascripts/components/admin/actors/admin_actors_page.jsx
@@ -1,0 +1,11 @@
+import React, { Component } from 'react'
+
+export default class AdminActorsPage extends Component {
+  render() {
+    return (
+      <div>
+        {this.props.children}
+      </div>
+    )
+  }
+}

--- a/app/assets/javascripts/components/admin/admin_menu.jsx
+++ b/app/assets/javascripts/components/admin/admin_menu.jsx
@@ -6,7 +6,7 @@ export default class AdminMenu extends Component {
     return (
       <div>
         <ul role="nav">
-          <li><Link to="/admin" activeClassName='active'>管理TOP</Link></li>
+          <li><Link to="/admin" activeClassName='active' onlyActiveOnIndex={true}>管理TOP</Link></li>
           <li><Link to="/admin/animes" activeClassName='active'>アニメ</Link></li>
           <li><Link to="/admin/actors" activeClassName='active'>声優</Link></li>
         </ul>

--- a/app/assets/javascripts/components/admin/animes/admin_anime_detail.jsx
+++ b/app/assets/javascripts/components/admin/animes/admin_anime_detail.jsx
@@ -1,5 +1,4 @@
 import React, { Component } from 'react'
-import AdminAnimeRow from './admin_anime_row.jsx'
 
 export default React.createClass({
   loadAnimesFromServer() {

--- a/app/assets/javascripts/components/admin/animes/admin_animes_page.jsx
+++ b/app/assets/javascripts/components/admin/animes/admin_animes_page.jsx
@@ -1,0 +1,11 @@
+import React, { Component } from 'react'
+
+export default class AdminAnimesPage extends Component {
+  render() {
+    return (
+      <div>
+        {this.props.children}
+      </div>
+    )
+  }
+}

--- a/app/assets/javascripts/components/navbar.jsx
+++ b/app/assets/javascripts/components/navbar.jsx
@@ -6,7 +6,7 @@ export default class Navbar extends Component {
     return (
       <div>
         <ul>
-          <li><Link to='/' activeClassName='active'>TOP</Link></li>
+          <li><Link to='/' activeClassName='active' onlyActiveOnIndex={true}>TOP</Link></li>
         </ul>
       </div>
     );

--- a/app/assets/javascripts/routes.jsx
+++ b/app/assets/javascripts/routes.jsx
@@ -5,8 +5,10 @@ import { Router, Route, browserHistory, IndexRoute } from 'react-router'
 import App from './components/app.jsx'
 import Welcome from './components/welcome/welcome.jsx'
 import Admin from './components/admin/admin.jsx'
+import AdminAnimesPage from './components/admin/animes/admin_animes_page.jsx'
 import AdminAnimes from './components/admin/animes/admin_animes.jsx'
 import AdminAnime from './components/admin/animes/admin_anime.jsx'
+import AdminActorsPage from './components/admin/actors/admin_actors_page.jsx'
 import AdminActors from './components/admin/actors/admin_actors.jsx'
 import AdminActor from './components/admin/actors/admin_actor.jsx'
 
@@ -15,10 +17,14 @@ const routes = (
     <Route path="/" component={App}>
       <IndexRoute component={Welcome} />
       <Route path="/admin" component={Admin}>
-        <Route path="/admin/animes" component={AdminAnimes} />
-        <Route path="/admin/animes/:animeId" component={AdminAnime} />
-        <Route path="/admin/actors" component={AdminActors} />
-        <Route path="/admin/actors/:actorId" component={AdminActor} />
+        <Route path="/admin/animes" component={AdminAnimesPage}>
+          <IndexRoute component={AdminAnimes} />
+          <Route path="/admin/animes/:animeId" component={AdminAnime} />
+        </Route>
+        <Route path="/admin/actors" component={AdminActorsPage}>
+          <IndexRoute component={AdminActors} />
+          <Route path="/admin/actors/:actorId" component={AdminActor} />
+        </Route>
       </Route>
     </Route>
   </Router>


### PR DESCRIPTION
## 事象

- `/`以下は全てTOP画面のアクティブリンクになってしまい、`/admin`以下は全て管理画面のアクティブリンクになっていた。
- アニメの管理画面は詳細ページでは「アニメ」メニューがアクティブリンクならなかった
- 声優の管理画面は詳細ページでは「声優」メニューがアクティブリンクにならなかった

## 対応内容

- アニメの管理画面は詳細ページで「アニメ」がアクティブリンクになるようにしました
- 声優の管理画面は詳細ページで「声優」がアクティブリンクになるようにしました
- 全てのページで「TOP」がアクティブリンクにならないようにしました
- 全ての管理ぺp時で「管理TOP」がアクティブリンクにならないようにしました

## 対応理由

アクティブリンクを正しく設定するため

