### PR TITLE
npmパッケージのアップグレード

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,19 +48,19 @@
     "browserify": "^13.1.1",
     "browserify-incremental": "^3.1.1",
     "enzyme": "^2.6.0",
-    "eslint": "^3.10.2",
-    "eslint-plugin-react": "^6.7.1",
+    "eslint": "^3.11.1",
+    "eslint-plugin-react": "^6.8.0",
     "jest": "^17.0.3",
     "jest-cli": "^17.0.3",
-    "react": "^15.4.0",
-    "react-addons-test-utils": "^15.4.0",
-    "react-dom": "^15.4.0",
-    "react-test-renderer": "^15.4.0",
+    "react": "^15.4.1",
+    "react-addons-test-utils": "^15.4.1",
+    "react-dom": "^15.4.1",
+    "react-test-renderer": "^15.4.1",
     "react-router": "^3.0.0",
     "reactify": "^1.1.1"
   },
   "dependencies": {
-    "react": "^15.3.2",
-    "react-dom": "^15.3.2"
+    "react": "^15.4.1",
+    "react-dom": "^15.4.1"
   }
 }


### PR DESCRIPTION
## 対応内容

```
 react                    ^15.4.0  →  ^15.4.1 
 react-dom                ^15.4.0  →  ^15.4.1 
 eslint                   ^3.10.2  →  ^3.11.1 
 eslint-plugin-react       ^6.7.1  →   ^6.8.0 
 react-addons-test-utils  ^15.4.0  →  ^15.4.1 
 react-test-renderer      ^15.4.0  →  ^15.4.1 
```

## 対応理由

しばらくアップグレードしていなかったため。（というかgreenkeeper動いてない？
