### PR TITLE
環境変数でAccess-Control-Allow-Originを設定＆環境変数のサンプル追加

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,4 +1,5 @@
 ORIGIN=
+ALLOW_ORIGIN=
 
 # production
 POSTGRESQL_USERNAME=

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,7 +23,7 @@ module AnimeMusic
 
     config.action_dispatch.default_headers = {
       'Access-Control-Allow-Credentials' => 'true',
-      'Access-Control-Allow-Origin' => 'http://localhost:8080',
+      'Access-Control-Allow-Origin' => ENV['ALLOW_ORIGIN'],
       'Access-Control-Request-Method' => '*'
     }
   end

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "browserify": "^13.1.1",
     "browserify-incremental": "^3.1.1",
     "compression": "^1.6.2",
+    "css-loader": "^0.26.1",
     "dotenv": "^2.0.0",
     "enzyme": "^2.7.0",
     "eslint": "^3.12.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,7 +16,8 @@ module.exports = {
 
   plugins: process.env.NODE_ENV === 'production' ? [
     new webpack.DefinePlugin({
-      NODE_ENV : JSON.stringify(process.env.NODE_ENV)
+      NODE_ENV : JSON.stringify(process.env.NODE_ENV),
+      ORIGIN : JSON.stringify(process.env.ORIGIN)
     }),
     new webpack.optimize.DedupePlugin(),
     new webpack.optimize.OccurrenceOrderPlugin(),


### PR DESCRIPTION
## 対応内容

- `Access-Control-Allow-Origin`を環境変数で設定できるようにしました
- production環境でも環境変数`ORIGIN`を設定するようにしました
- 環境変数のサンプルを追加しました

## 対応理由

本番環境では、ドメイン名が異なるため