### PR TITLE
assets:precompileを無効化

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -31,5 +31,7 @@ module AnimeMusic
     config.i18n.default_locale = :ja
     config.time_zone = 'Tokyo'
     config.active_record.default_timezone = :local
+
+    config.assets.precompile = []
   end
 end


### PR DESCRIPTION
## 対応内容

assets:precompileを強制的に無効化しました

## 対応理由

herokuでのデプロイにproductionモードであるために`rake assets:precompile`が実行される。
そのため、rails側でsassファイルを読み込むことができず（gemを入れていないため）herokuデプロイ時にエラーが発生している。
このプロジェクトでは、アセットパイプラインを利用していないため、実行しないように修正したい。
