### PR TITLE
sass-railsを入れ、assets:precompileをするように変更

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'slack-notifier'
 gem 'dotenv-rails'
 gem 'rails-i18n'
 gem 'rack-cors'
+gem 'sass-rails'
 
 group :development, :test do
   gem 'byebug', platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -251,6 +251,13 @@ GEM
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.8.1)
     rubyzip (1.2.0)
+    sass (3.4.23)
+    sass-rails (5.0.6)
+      railties (>= 4.0.0, < 6)
+      sass (~> 3.1)
+      sprockets (>= 2.8, < 4.0)
+      sprockets-rails (>= 2.0, < 4.0)
+      tilt (>= 1.1, < 3)
     selenium-webdriver (3.0.5)
       childprocess (~> 0.5)
       rubyzip (~> 1.0)
@@ -340,6 +347,7 @@ DEPENDENCIES
   rspec-json_matcher
   rspec-rails
   rubocop
+  sass-rails
   selenium-webdriver
   shoulda-matchers
   simplecov

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,7 +31,5 @@ module AnimeMusic
     config.i18n.default_locale = :ja
     config.time_zone = 'Tokyo'
     config.active_record.default_timezone = :local
-
-    config.assets.precompile = []
   end
 end


### PR DESCRIPTION
## 対応内容

強制的にassets:precompileをしないように修正した予定だが、実行されていたため
足りないgem`sass-rails`をいれ、assets:precompileでエラーが発生しないように修正しました