### PR TITLE
管理画面：アニメ詳細画面にサムネイル表示の枠を追加

### DIFF
--- a/app/assets/javascripts/__tests__/admin/animes/detail/_admin_anime_detail.test.js
+++ b/app/assets/javascripts/__tests__/admin/animes/detail/_admin_anime_detail.test.js
@@ -10,6 +10,7 @@ expect.extend(expectJSX)
 
 import AdminAnimeDetail from '../../../../components/admin/animes/detail/_admin_anime_detail'
 import AdminAnimeTitle from '../../../../components/admin/animes/detail/_admin_anime_title'
+import AdminAnimeThumbnail from '../../../../components/admin/animes/detail/_admin_anime_thumbnail'
 jest.unmock('../../../../components/admin/animes/detail/_admin_anime_detail')
 
 describe('AdminAnimeDetailComponent', () => {
@@ -26,7 +27,7 @@ describe('AdminAnimeDetailComponent', () => {
     const component = shallow(
       <AdminAnimeDetail url='api/admin/animes/1' />
     )
-    component.setState({anime: { id: 1, title: 'アニメタイトル', summary: 'アニメサマリ', wiki_url: 'https://wiki.com' }})
+    component.setState({anime: { id: 1, title: 'アニメタイトル', summary: 'アニメサマリ', wiki_url: 'https://wiki.com', picture: 'https://picture.com' }})
 
     let actualElement = component.single(reactElementToJSXString)
     let expectedElement = (
@@ -34,6 +35,7 @@ describe('AdminAnimeDetailComponent', () => {
         <div className='panel panel-default'>
           <div className='panel-body'>
             <AdminAnimeTitle id={1} title='アニメタイトル' />
+            <AdminAnimeThumbnail id={1} title='アニメタイトル' picture='https://picture.com'/>
             {'アニメサマリ'}
           </div>
         </div>

--- a/app/assets/javascripts/__tests__/admin/animes/detail/_admin_anime_detail.test.js
+++ b/app/assets/javascripts/__tests__/admin/animes/detail/_admin_anime_detail.test.js
@@ -35,7 +35,7 @@ describe('AdminAnimeDetailComponent', () => {
         <div className='panel panel-default'>
           <div className='panel-body'>
             <AdminAnimeTitle id={1} title='アニメタイトル' />
-            <AdminAnimeThumbnail id={1} title='アニメタイトル' picture='https://picture.com'/>
+            <AdminAnimeThumbnail id={1} picture='https://picture.com' title='アニメタイトル' />
             {'アニメサマリ'}
           </div>
         </div>

--- a/app/assets/javascripts/__tests__/admin/animes/detail/_admin_anime_thumbnail.test.js
+++ b/app/assets/javascripts/__tests__/admin/animes/detail/_admin_anime_thumbnail.test.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import expect from 'expect'
-import { renderIntoDocument } from 'react-addons-test-utils'
 import { shallow } from 'enzyme'
 import expectJSX from 'expect-jsx'
 import 'jest-fetch-mock'
@@ -21,8 +20,8 @@ describe('AdminAnimesTableComponent', () => {
     let expectedElement = (
       <div className='adminAnimeThumbnailComponent'>
         <div className='col-xs-6 col-md-3'>
-          <a href='#' className='thumbnail'>
-            <img src='api/admin/animes' alt='アニメタイトル' />
+          <a className='thumbnail' href='#'>
+            <img alt='アニメタイトル' src='api/admin/animes' />
           </a>
         </div>
       </div>

--- a/app/assets/javascripts/__tests__/admin/animes/detail/_admin_anime_thumbnail.test.js
+++ b/app/assets/javascripts/__tests__/admin/animes/detail/_admin_anime_thumbnail.test.js
@@ -1,0 +1,32 @@
+import React from 'react'
+import expect from 'expect'
+import { renderIntoDocument } from 'react-addons-test-utils'
+import { shallow } from 'enzyme'
+import expectJSX from 'expect-jsx'
+import 'jest-fetch-mock'
+import reactElementToJSXString from 'react-element-to-jsx-string'
+
+expect.extend(expectJSX)
+
+import AdminAnimesThumbnail from '../../../../components/admin/animes/detail/_admin_anime_thumbnail'
+jest.unmock('../../../../components/admin/animes/detail/_admin_anime_thumbnail')
+
+describe('AdminAnimesTableComponent', () => {
+  it('DOMが出力されること', () => {
+    const component = shallow(
+      <AdminAnimesThumbnail id='1' picture='api/admin/animes' title='アニメタイトル' />
+    )
+
+    let actualElement = component.single(reactElementToJSXString)
+    let expectedElement = (
+      <div className='adminAnimeThumbnailComponent'>
+        <div className='col-xs-6 col-md-3'>
+          <a href='#' className='thumbnail'>
+            <img src='api/admin/animes' alt='アニメタイトル' />
+          </a>
+        </div>
+      </div>
+    )
+    expect(actualElement).toEqualJSX(expectedElement)
+  })
+})

--- a/app/assets/javascripts/components/admin/animes/detail/_admin_anime_detail.js
+++ b/app/assets/javascripts/components/admin/animes/detail/_admin_anime_detail.js
@@ -2,6 +2,7 @@ import React, { Component, PropTypes } from 'react'
 import { origin } from './../../../../origin.js'
 
 import AdminAnimeTitle from './_admin_anime_title'
+import AdminAnimeThumbnail from './_admin_anime_thumbnail'
 
 export default class AdminAnimeDetail extends Component {
   constructor(props) {
@@ -32,6 +33,7 @@ export default class AdminAnimeDetail extends Component {
         <div className='panel panel-default'>
           <div className='panel-body'>
             <AdminAnimeTitle id={this.state.anime.id} title={this.state.anime.title} />
+            <AdminAnimeThumbnail id={this.state.anime.id} picture={this.state.anime.picture} title={this.state.anime.title} />
             {this.state.anime.summary}
           </div>
         </div>

--- a/app/assets/javascripts/components/admin/animes/detail/_admin_anime_detail.js
+++ b/app/assets/javascripts/components/admin/animes/detail/_admin_anime_detail.js
@@ -8,7 +8,7 @@ export default class AdminAnimeDetail extends Component {
   constructor(props) {
     super(props)
     this.state = {
-      anime: {id: 0, title: '', summary: '', wiki_url: ''}
+      anime: {id: 0, title: '', summary: '', wiki_url: '', picture: ''}
     }
   }
 

--- a/app/assets/javascripts/components/admin/animes/detail/_admin_anime_thumbnail.js
+++ b/app/assets/javascripts/components/admin/animes/detail/_admin_anime_thumbnail.js
@@ -1,19 +1,12 @@
 import React, { Component, PropTypes } from 'react'
-import { origin } from './../../../../origin.js'
 
 export default class AdminAnimeThumbnail extends Component {
-  constructor(props) {
-    super(props)
-    this.state = {
-    }
-  }
-
   render() {
     return (
       <div className='adminAnimeThumbnailComponent'>
         <div className='col-xs-6 col-md-3'>
-          <a href='#' className='thumbnail'>
-            <img src={this.props.picture} alt={this.props.title} />
+          <a className='thumbnail' href='#'>
+            <img alt={this.props.title} src={this.props.picture} />
           </a>
         </div>
       </div>
@@ -22,5 +15,7 @@ export default class AdminAnimeThumbnail extends Component {
 }
 
 AdminAnimeThumbnail.propTypes = {
-  id: PropTypes.number.isRequired
+  id: PropTypes.number.isRequired,
+  title: PropTypes.string.isRequired,
+  picture: PropTypes.string.isRequired
 }

--- a/app/assets/javascripts/components/admin/animes/detail/_admin_anime_thumbnail.js
+++ b/app/assets/javascripts/components/admin/animes/detail/_admin_anime_thumbnail.js
@@ -1,0 +1,26 @@
+import React, { Component, PropTypes } from 'react'
+import { origin } from './../../../../origin.js'
+
+export default class AdminAnimeThumbnail extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+    }
+  }
+
+  render() {
+    return (
+      <div className='adminAnimeThumbnailComponent'>
+        <div className='col-xs-6 col-md-3'>
+          <a href='#' className='thumbnail'>
+            <img src={this.props.picture} alt={this.props.title} />
+          </a>
+        </div>
+      </div>
+    )
+  }
+}
+
+AdminAnimeThumbnail.propTypes = {
+  id: PropTypes.number.isRequired
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -19,6 +19,11 @@
   display: inline-block;
 }
 
+.thumbnail {
+  width: 171px;
+  height: 180px;
+}
+
 // Component CSS
 .messageBoxComponent {
   display: inline-block;

--- a/app/views/api/admin/animes/show.json.jbuilder
+++ b/app/views/api/admin/animes/show.json.jbuilder
@@ -2,3 +2,4 @@ json.id @anime.id
 json.title @anime.title
 json.summary @anime.summary
 json.wiki_url @anime.wiki_url
+json.picture @anime.picture

--- a/spec/requests/admin/animes_spec.rb
+++ b/spec/requests/admin/animes_spec.rb
@@ -40,7 +40,8 @@ describe 'GET /api/admin/animes/:id', autodoc: true do
       id: anime.id,
       title: anime.title,
       summary: anime.summary,
-      wiki_url: anime.wiki_url
+      wiki_url: anime.wiki_url,
+      picture: anime.picture
     }
     expect(response.body).to be_json_as(json)
   end


### PR DESCRIPTION
## 対応内容

管理画面：アニメ詳細画面にサムネイルを表示できる枠を追加しました。
レイアウトのみの対応です。