### PR TITLE
管理画面：アニメ詳細画面にシーズン情報を表示

### DIFF
--- a/app/assets/javascripts/__tests__/admin/animes/detail/_admin_anime_detail.test.js
+++ b/app/assets/javascripts/__tests__/admin/animes/detail/_admin_anime_detail.test.js
@@ -38,9 +38,14 @@ describe('AdminAnimeDetailComponent', () => {
         <div className='panel panel-default'>
           <div className='panel-body'>
             <AdminAnimeTitle id={1} title='アニメタイトル' />
-            <AdminAnimeThumbnail id={1} picture='https://picture.com' title='アニメタイトル' />
-            {'アニメサマリ'}
-            <hr />
+            <div className="row">
+              <div className="col-xs-6 col-md-3">
+                <AdminAnimeThumbnail id={1} picture='https://picture.com' title='アニメタイトル' />
+              </div>
+              <div className="col-xs-6 col-md-9">
+                {'アニメサマリ'}
+              </div>
+            </div>
             <AdminAnimeSeasons seasons={seasons} />
           </div>
         </div>

--- a/app/assets/javascripts/__tests__/admin/animes/detail/_admin_anime_detail.test.js
+++ b/app/assets/javascripts/__tests__/admin/animes/detail/_admin_anime_detail.test.js
@@ -11,6 +11,7 @@ expect.extend(expectJSX)
 import AdminAnimeDetail from '../../../../components/admin/animes/detail/_admin_anime_detail'
 import AdminAnimeTitle from '../../../../components/admin/animes/detail/_admin_anime_title'
 import AdminAnimeThumbnail from '../../../../components/admin/animes/detail/_admin_anime_thumbnail'
+import AdminAnimeSeasons from '../../../../components/admin/animes/detail/_admin_anime_seasons'
 jest.unmock('../../../../components/admin/animes/detail/_admin_anime_detail')
 
 describe('AdminAnimeDetailComponent', () => {
@@ -21,13 +22,15 @@ describe('AdminAnimeDetailComponent', () => {
     expect(component.state.anime.title).toBe('')
     expect(component.state.anime.summary).toBe('')
     expect(component.state.anime.wiki_url).toBe('')
+    expect(component.state.anime.seasons).toEqual([])
   })
 
   it('設定した値が表示されること', () => {
     const component = shallow(
       <AdminAnimeDetail url='api/admin/animes/1' />
     )
-    component.setState({anime: { id: 1, title: 'アニメタイトル', summary: 'アニメサマリ', wiki_url: 'https://wiki.com', picture: 'https://picture.com' }})
+    const seasons = [{id: 1, phase: '1', name: 'アニメタイトルシーズン１'}]
+    component.setState({anime: { id: 1, title: 'アニメタイトル', summary: 'アニメサマリ', wiki_url: 'https://wiki.com', picture: 'https://picture.com', seasons: seasons }})
 
     let actualElement = component.single(reactElementToJSXString)
     let expectedElement = (
@@ -37,6 +40,8 @@ describe('AdminAnimeDetailComponent', () => {
             <AdminAnimeTitle id={1} title='アニメタイトル' />
             <AdminAnimeThumbnail id={1} picture='https://picture.com' title='アニメタイトル' />
             {'アニメサマリ'}
+            <hr />
+            <AdminAnimeSeasons seasons={seasons} />
           </div>
         </div>
       </div>

--- a/app/assets/javascripts/__tests__/admin/animes/detail/_admin_anime_season.test.js
+++ b/app/assets/javascripts/__tests__/admin/animes/detail/_admin_anime_season.test.js
@@ -1,0 +1,30 @@
+import React from 'react'
+import expect from 'expect'
+import { createRenderer } from 'react-addons-test-utils'
+import expectJSX from 'expect-jsx'
+
+expect.extend(expectJSX)
+
+import AdminAnimeSeason from '../../../../components/admin/animes/detail/_admin_anime_season'
+jest.unmock('../../../../components/admin/animes/detail/_admin_anime_season')
+
+describe('AdminAnimeSeasonComponent', () => {
+  it('propsに設定した値が表示されること', () => {
+    let renderer = createRenderer()
+    const season = { id: 1, phase: '1', name: 'アニメタイトルシーズン1', start_on: '2017-01-01', end_on: '' }
+    renderer.render(
+      <AdminAnimeSeason season={season} />
+    )
+    let actualElement = renderer.getRenderOutput()
+    let expectedElement = (
+      <div className='adminAnimeSeasonComponent'>
+        <div className='well well-lg'>
+          {'第1期：'}
+          {'2017-01-01〜：'}
+          <b>{'アニメタイトルシーズン1'}</b>
+        </div>
+      </div>
+    )
+    expect(actualElement).toEqualJSX(expectedElement)
+  })
+})

--- a/app/assets/javascripts/__tests__/admin/animes/detail/_admin_anime_seasons.test.js
+++ b/app/assets/javascripts/__tests__/admin/animes/detail/_admin_anime_seasons.test.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import expect from 'expect'
-import { renderIntoDocument } from 'react-addons-test-utils'
 import { shallow } from 'enzyme'
 import expectJSX from 'expect-jsx'
 import 'jest-fetch-mock'
@@ -16,7 +15,6 @@ describe('AdminAnimeSeasonsComponent', () => {
   it('DOMが出力されること', () => {
     const season1 = { id: '1', phase: '1', name: 'アニメタイトルシーズン1', start_on: '2016-03-01', end_on: '2016-07-01' }
     const season2 = { id: '2', phase: '2', name: 'アニメタイトルシーズン2', start_on: '2017-01-01', end_on: '' }
-    //component.setState({seasons: [season1, season2]})
     const component = shallow(
       <AdminAnimeSeasons seasons={[season1, season2]} />
     )

--- a/app/assets/javascripts/__tests__/admin/animes/detail/_admin_anime_seasons.test.js
+++ b/app/assets/javascripts/__tests__/admin/animes/detail/_admin_anime_seasons.test.js
@@ -1,0 +1,33 @@
+import React from 'react'
+import expect from 'expect'
+import { renderIntoDocument } from 'react-addons-test-utils'
+import { shallow } from 'enzyme'
+import expectJSX from 'expect-jsx'
+import 'jest-fetch-mock'
+import reactElementToJSXString from 'react-element-to-jsx-string'
+
+expect.extend(expectJSX)
+
+import AdminAnimeSeasons from '../../../../components/admin/animes/detail/_admin_anime_seasons'
+import AdminAnimeSeason from '../../../../components/admin/animes/detail/_admin_anime_season'
+jest.unmock('../../../../components/admin/animes/detail/_admin_anime_seasons')
+
+describe('AdminAnimeSeasonsComponent', () => {
+  it('DOMが出力されること', () => {
+    const season1 = { id: '1', phase: '1', name: 'アニメタイトルシーズン1', start_on: '2016-03-01', end_on: '2016-07-01' }
+    const season2 = { id: '2', phase: '2', name: 'アニメタイトルシーズン2', start_on: '2017-01-01', end_on: '' }
+    //component.setState({seasons: [season1, season2]})
+    const component = shallow(
+      <AdminAnimeSeasons seasons={[season1, season2]} />
+    )
+
+    let actualElement = component.single(reactElementToJSXString)
+    let expectedElement = (
+      <div className='adminAnimeSeasonsComponent'>
+        <AdminAnimeSeason key={1} season={season1} />
+        <AdminAnimeSeason key={2} season={season2} />
+      </div>
+    )
+    expect(actualElement).toEqualJSX(expectedElement)
+  })
+})

--- a/app/assets/javascripts/components/admin/animes/detail/_admin_anime_detail.js
+++ b/app/assets/javascripts/components/admin/animes/detail/_admin_anime_detail.js
@@ -3,12 +3,13 @@ import { origin } from './../../../../origin.js'
 
 import AdminAnimeTitle from './_admin_anime_title'
 import AdminAnimeThumbnail from './_admin_anime_thumbnail'
+import AdminAnimeSeasons from './_admin_anime_seasons'
 
 export default class AdminAnimeDetail extends Component {
   constructor(props) {
     super(props)
     this.state = {
-      anime: {id: 0, title: '', summary: '', wiki_url: '', picture: ''}
+      anime: {id: 0, title: '', summary: '', wiki_url: '', picture: '', seasons: []}
     }
   }
 
@@ -35,6 +36,8 @@ export default class AdminAnimeDetail extends Component {
             <AdminAnimeTitle id={this.state.anime.id} title={this.state.anime.title} />
             <AdminAnimeThumbnail id={this.state.anime.id} picture={this.state.anime.picture} title={this.state.anime.title} />
             {this.state.anime.summary}
+            <hr />
+            <AdminAnimeSeasons seasons={this.state.anime.seasons} />
           </div>
         </div>
       </div>

--- a/app/assets/javascripts/components/admin/animes/detail/_admin_anime_detail.js
+++ b/app/assets/javascripts/components/admin/animes/detail/_admin_anime_detail.js
@@ -34,9 +34,14 @@ export default class AdminAnimeDetail extends Component {
         <div className='panel panel-default'>
           <div className='panel-body'>
             <AdminAnimeTitle id={this.state.anime.id} title={this.state.anime.title} />
-            <AdminAnimeThumbnail id={this.state.anime.id} picture={this.state.anime.picture} title={this.state.anime.title} />
-            {this.state.anime.summary}
-            <hr />
+            <div className="row">
+              <div className="col-xs-6 col-md-3">
+                <AdminAnimeThumbnail id={this.state.anime.id} picture={this.state.anime.picture} title={this.state.anime.title} />
+              </div>
+              <div className="col-xs-6 col-md-9">
+                {this.state.anime.summary}
+              </div>
+            </div>
             <AdminAnimeSeasons seasons={this.state.anime.seasons} />
           </div>
         </div>

--- a/app/assets/javascripts/components/admin/animes/detail/_admin_anime_detail.js
+++ b/app/assets/javascripts/components/admin/animes/detail/_admin_anime_detail.js
@@ -36,7 +36,7 @@ export default class AdminAnimeDetail extends Component {
             <AdminAnimeTitle id={this.state.anime.id} title={this.state.anime.title} />
             <div className="row">
               <div className="col-xs-6 col-md-3">
-                <AdminAnimeThumbnail id={this.state.anime.id} picture={this.state.anime.picture} title={this.state.anime.title} />
+                <AdminAnimeThumbnail id={this.state.anime.id} picture={this.state.anime.picture || ''} title={this.state.anime.title} />
               </div>
               <div className="col-xs-6 col-md-9">
                 {this.state.anime.summary}

--- a/app/assets/javascripts/components/admin/animes/detail/_admin_anime_season.js
+++ b/app/assets/javascripts/components/admin/animes/detail/_admin_anime_season.js
@@ -1,11 +1,6 @@
 import React, { Component, PropTypes } from 'react'
-import { origin } from './../../../../origin.js'
 
 export default class AdminAnimeSeason extends Component {
-  constructor(props) {
-    super(props)
-  }
-
   render() {
     return (
       <div className='adminAnimeSeasonComponent'>

--- a/app/assets/javascripts/components/admin/animes/detail/_admin_anime_season.js
+++ b/app/assets/javascripts/components/admin/animes/detail/_admin_anime_season.js
@@ -4,7 +4,11 @@ export default class AdminAnimeSeason extends Component {
   render() {
     return (
       <div className='adminAnimeSeasonComponent'>
-        {this.props.season.phase}
+        <div className='well well-lg'>
+          第{this.props.season.phase}期：
+          {this.props.season.start_on}〜{this.props.season.end_on}：
+          <b>{this.props.season.name}</b>
+        </div>
       </div>
     )
   }

--- a/app/assets/javascripts/components/admin/animes/detail/_admin_anime_season.js
+++ b/app/assets/javascripts/components/admin/animes/detail/_admin_anime_season.js
@@ -1,0 +1,20 @@
+import React, { Component, PropTypes } from 'react'
+import { origin } from './../../../../origin.js'
+
+export default class AdminAnimeSeason extends Component {
+  constructor(props) {
+    super(props)
+  }
+
+  render() {
+    return (
+      <div className='adminAnimeSeasonComponent'>
+        {this.props.season.phase}
+      </div>
+    )
+  }
+}
+
+AdminAnimeSeason.propTypes = {
+  season: PropTypes.object.isRequired
+}

--- a/app/assets/javascripts/components/admin/animes/detail/_admin_anime_season.js
+++ b/app/assets/javascripts/components/admin/animes/detail/_admin_anime_season.js
@@ -5,8 +5,8 @@ export default class AdminAnimeSeason extends Component {
     return (
       <div className='adminAnimeSeasonComponent'>
         <div className='well well-lg'>
-          第{this.props.season.phase}期：
-          {this.props.season.start_on}〜{this.props.season.end_on}：
+          {'第' + this.props.season.phase + '期：'}
+          {this.props.season.start_on + '〜' + this.props.season.end_on + '：'}
           <b>{this.props.season.name}</b>
         </div>
       </div>

--- a/app/assets/javascripts/components/admin/animes/detail/_admin_anime_seasons.js
+++ b/app/assets/javascripts/components/admin/animes/detail/_admin_anime_seasons.js
@@ -2,6 +2,13 @@ import React, { Component, PropTypes } from 'react'
 import AdminAnimeSeason from './_admin_anime_season'
 
 export default class AdminAnimeSeasons extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      seasons: []
+    }
+  }
+
   render() {
     return (
       <div className='adminAnimeSeasonsComponent'>

--- a/app/assets/javascripts/components/admin/animes/detail/_admin_anime_seasons.js
+++ b/app/assets/javascripts/components/admin/animes/detail/_admin_anime_seasons.js
@@ -1,6 +1,4 @@
 import React, { Component, PropTypes } from 'react'
-import { origin } from './../../../../origin.js'
-
 import AdminAnimeSeason from './_admin_anime_season'
 
 export default class AdminAnimeSeasons extends Component {
@@ -8,7 +6,7 @@ export default class AdminAnimeSeasons extends Component {
     return (
       <div className='adminAnimeSeasonsComponent'>
         {this.props.seasons.map((season) =>
-          <AdminAnimeSeason season={season} key={season.id} />
+          <AdminAnimeSeason key={season.id} season={season} />
         )}
       </div>
     )

--- a/app/assets/javascripts/components/admin/animes/detail/_admin_anime_seasons.js
+++ b/app/assets/javascripts/components/admin/animes/detail/_admin_anime_seasons.js
@@ -1,0 +1,20 @@
+import React, { Component, PropTypes } from 'react'
+import { origin } from './../../../../origin.js'
+
+import AdminAnimeSeason from './_admin_anime_season'
+
+export default class AdminAnimeSeasons extends Component {
+  render() {
+    return (
+      <div className='adminAnimeSeasonsComponent'>
+        {this.props.seasons.map((season) =>
+          <AdminAnimeSeason season={season} key={season.id} />
+        )}
+      </div>
+    )
+  }
+}
+
+AdminAnimeSeasons.propTypes = {
+  seasons: PropTypes.array.isRequired
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -45,6 +45,10 @@
   padding-left: 20px;
 }
 
+.adminAnimeSeasonComponent {
+  padding: 10px;
+}
+
 // Bootstrap Overrides CSS
 .panel-body {
   position: relative;

--- a/app/controllers/api/admin/animes_controller.rb
+++ b/app/controllers/api/admin/animes_controller.rb
@@ -6,7 +6,9 @@ class Api::Admin::AnimesController < Api::BaseController
     @animes = Anime.all
   end
 
-  def show; end
+  def show
+    @seasons = @anime.seasons
+  end
 
   def update
     if @anime.update(anime_params)

--- a/app/views/api/admin/animes/show.json.jbuilder
+++ b/app/views/api/admin/animes/show.json.jbuilder
@@ -3,3 +3,13 @@ json.title @anime.title
 json.summary @anime.summary
 json.wiki_url @anime.wiki_url
 json.picture @anime.picture
+
+json.seasons do
+  json.array! @seasons do |season|
+    json.id season.id
+    json.phase season.phase
+    json.name season.name
+    json.start_on season.start_on
+    json.end_on season.end_on
+  end
+end

--- a/spec/factories/seasons.rb
+++ b/spec/factories/seasons.rb
@@ -2,7 +2,7 @@
 FactoryGirl.define do
   factory :season do
     anime
-    sequence(:phase) { |n| "第#{n}期" }
+    sequence(:phase) { |n| n }
     sequence(:name) { |n| "シーズン名#{n}" }
     start_on { Time.zone.today - 10.days }
     end_on { [Time.zone.today, nil].sample }

--- a/spec/requests/admin/animes_spec.rb
+++ b/spec/requests/admin/animes_spec.rb
@@ -31,6 +31,8 @@ end
 
 describe 'GET /api/admin/animes/:id', autodoc: true do
   let!(:anime) { create(:anime) }
+  let!(:season1) { create(:season, anime: anime) }
+  let!(:season2) { create(:season, anime: anime) }
 
   it '200とアニメ詳細が返ってくること' do
     get "/api/admin/animes/#{anime.id}"
@@ -41,7 +43,23 @@ describe 'GET /api/admin/animes/:id', autodoc: true do
       title: anime.title,
       summary: anime.summary,
       wiki_url: anime.wiki_url,
-      picture: anime.picture
+      picture: anime.picture,
+      seasons: [
+        {
+          id: season1.id,
+          phase: season1.phase,
+          name: season1.name,
+          start_on: season1.start_on.strftime('%Y-%m-%d'),
+          end_on: season1.end_on.try(:strftime, '%Y-%m-%d')
+        },
+        {
+          id: season2.id,
+          phase: season2.phase,
+          name: season2.name,
+          start_on: season2.start_on.strftime('%Y-%m-%d'),
+          end_on: season2.end_on.try(:strftime, '%Y-%m-%d')
+        }
+      ]
     }
     expect(response.body).to be_json_as(json)
   end


### PR DESCRIPTION
## 対応内容

- 管理画面：アニメ詳細画面にシーズン情報を表示するようにしました
- 管理画面：アニメ詳細画面にアニメ情報を返すAPIにシーズン情報を追加しました