### PR TITLE
アニメ詳細画面のデザイン微調整＆改行したサマリを登録できるように修正

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -38,7 +38,6 @@
     "react/jsx-sort-props": 1,
     "react/jsx-uses-react": 1,
     "react/jsx-uses-vars": 1,
-    "react/no-danger": 1,
     "react/no-did-mount-set-state": 1,
     "react/no-did-update-set-state": 1,
     "react/no-direct-mutation-state": 1,

--- a/app/assets/javascripts/__tests__/admin/animes/detail/_admin_anime_body.test.js
+++ b/app/assets/javascripts/__tests__/admin/animes/detail/_admin_anime_body.test.js
@@ -14,7 +14,7 @@ describe('AdminAnimeBodyComponent', () => {
   it('propsに設定した値が出力されること', () => {
     let renderer = createRenderer()
     renderer.render(
-      <AdminAnimeBody id={1} onLoadAnime={jest.fn()} summary='アニメサマリ' wiki_url='https://wiki.com' />
+      <AdminAnimeBody id={1} handleLoadAnime={jest.fn()} summary='アニメサマリ' wiki_url='https://wiki.com' />
     )
     let actualElement = renderer.getRenderOutput()
     let expectedElement = (
@@ -40,7 +40,7 @@ describe('AdminAnimeBodyComponent', () => {
 
   it('state初期値が設定されていること', () => {
     const component = renderIntoDocument(
-      <AdminAnimeBody id={1} onLoadAnime={jest.fn()} summary='アニメサマリ' wiki_url='https://wiki.com' />
+      <AdminAnimeBody id={1} handleLoadAnime={jest.fn()} summary='アニメサマリ' wiki_url='https://wiki.com' />
     )
     expect(component.state.editingBody).toBe(false)
     expect(component.state.loadingBody).toBe(false)
@@ -48,7 +48,7 @@ describe('AdminAnimeBodyComponent', () => {
 
   it('アイコンをクリックすると編集モードになること', () => {
     const component = renderIntoDocument(
-      <AdminAnimeBody id={1} onLoadAnime={jest.fn()} summary='アニメサマリ' wiki_url='https://wiki.com' />
+      <AdminAnimeBody id={1} handleLoadAnime={jest.fn()} summary='アニメサマリ' wiki_url='https://wiki.com' />
     )
     expect(component.state.editingBody).toBe(false)
 

--- a/app/assets/javascripts/__tests__/admin/animes/detail/_admin_anime_body.test.js
+++ b/app/assets/javascripts/__tests__/admin/animes/detail/_admin_anime_body.test.js
@@ -21,7 +21,7 @@ describe('AdminAnimeBodyComponent', () => {
       <div className='adminAnimeBodyComponent'>
         <div className='not-editing-body'>
           <div className='summary'>
-            {'アニメサマリ'}
+            <div dangerouslySetInnerHTML={{__html: 'アニメサマリ'}} />
           </div>
           <div className='wiki-url'>
             <a href='https://wiki.com' target='_blank'>{'https://wiki.com'}</a>

--- a/app/assets/javascripts/__tests__/admin/animes/detail/_admin_anime_body.test.js
+++ b/app/assets/javascripts/__tests__/admin/animes/detail/_admin_anime_body.test.js
@@ -14,7 +14,7 @@ describe('AdminAnimeBodyComponent', () => {
   it('propsに設定した値が出力されること', () => {
     let renderer = createRenderer()
     renderer.render(
-      <AdminAnimeBody id={1} handleLoadAnime={jest.fn()} summary='アニメサマリ' wiki_url='https://wiki.com' />
+      <AdminAnimeBody handleLoadAnime={jest.fn()} id={1} summary='アニメサマリ' wiki_url='https://wiki.com' />
     )
     let actualElement = renderer.getRenderOutput()
     let expectedElement = (
@@ -40,7 +40,7 @@ describe('AdminAnimeBodyComponent', () => {
 
   it('state初期値が設定されていること', () => {
     const component = renderIntoDocument(
-      <AdminAnimeBody id={1} handleLoadAnime={jest.fn()} summary='アニメサマリ' wiki_url='https://wiki.com' />
+      <AdminAnimeBody handleLoadAnime={jest.fn()} id={1} summary='アニメサマリ' wiki_url='https://wiki.com' />
     )
     expect(component.state.editingBody).toBe(false)
     expect(component.state.loadingBody).toBe(false)
@@ -48,7 +48,7 @@ describe('AdminAnimeBodyComponent', () => {
 
   it('アイコンをクリックすると編集モードになること', () => {
     const component = renderIntoDocument(
-      <AdminAnimeBody id={1} handleLoadAnime={jest.fn()} summary='アニメサマリ' wiki_url='https://wiki.com' />
+      <AdminAnimeBody handleLoadAnime={jest.fn()} id={1} summary='アニメサマリ' wiki_url='https://wiki.com' />
     )
     expect(component.state.editingBody).toBe(false)
 

--- a/app/assets/javascripts/__tests__/admin/animes/detail/_admin_anime_detail.test.js
+++ b/app/assets/javascripts/__tests__/admin/animes/detail/_admin_anime_detail.test.js
@@ -31,7 +31,7 @@ describe('AdminAnimeDetailComponent', () => {
                 <AdminAnimeThumbnail id={1} picture='https://picture.com' title='アニメタイトル' />
               </div>
               <div className="col-xs-6 col-md-9">
-                <AdminAnimeBody id={1} handleLoadAnime={jest.fn()} summary='アニメサマリ' wiki_url='https://wiki.com' />
+                <AdminAnimeBody handleLoadAnime={jest.fn()} id={1} summary='アニメサマリ' wiki_url='https://wiki.com' />
               </div>
             </div>
           </div>

--- a/app/assets/javascripts/components/admin/animes/detail/_admin_anime_body.js
+++ b/app/assets/javascripts/components/admin/animes/detail/_admin_anime_body.js
@@ -109,10 +109,11 @@ export default class AdminAnimeBody extends Component {
       </div>
     )
 
+    const htmlString = { __html: this.props.summary.replace(/\r?\n/g, '<br>') }
     let not_editing_jsx = (
       <div className='not-editing-body'>
         <div className='summary'>
-          {this.props.summary}
+          <div dangerouslySetInnerHTML={htmlString} />
         </div>
         <div className='wiki-url'>
           <a href={this.props.wiki_url} target='_blank'>{this.props.wiki_url}</a>

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -64,7 +64,7 @@
   }
 
   .summary {
-    height: 85px;
+    min-height: 85px;
   }
 }
 

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -38,13 +38,33 @@
 }
 
 .adminAnimeBodyComponent {
+  .not-editing-body {
+    min-height: 210px;
+    padding: 10px;
+    .wiki-url {
+      margin-left: 3px;
+    }
+    .summary {
+      margin-top: -3px;
+      margin-left: 3px;
+    }
+    .pull-right {
+      position: absolute;
+      bottom: 10px;
+      right: 20px;
+    }
+  }
+  .editing-body {
+    min-height: 210px;
+  }
+
   .wiki-url {
     padding-top: 15px;
     padding-bottom: 15px;
   }
 
-  .not-editing-body {
-    padding: 20px;
+  .summary {
+    height: 85px;
   }
 }
 


### PR DESCRIPTION
## 対応内容

- アニメ詳細画面のデザインの微調整を行いました
- 改行したアニメのサマリを登録できなかった＆表示できなかったので、修正しました