### PR TITLE
管理者ユーザーを追加

### DIFF
--- a/app/controllers/api/sessions_controller.rb
+++ b/app/controllers/api/sessions_controller.rb
@@ -4,6 +4,7 @@ class Api::SessionsController < Api::BaseController
   def create
     @session = Session.new(login_params)
     render_error @session, 401 unless @session.save
+    @user = @session.user
     @session
   end
 

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Admin < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -3,7 +3,7 @@
 class Session
   include ActiveModel::Model
 
-  attr_accessor :email, :password
+  attr_accessor :email, :password, :user
   validates :email, presence: true,
                     email_format: { allow_blank: true, message: :invalid },
                     length: { maximum: Settings.user.email.maximum_length }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,8 @@ class User < ApplicationRecord
   has_secure_password
   tokenizable
 
+  has_one :admin
+
   validates :email, presence: true
 
   enum status: { inactive: 1, registered: 2 }
@@ -13,5 +15,9 @@ class User < ApplicationRecord
       :access, size: Settings.access_token.length,
                expires_at: Settings.access_token.expire_after.seconds.from_now
     )
+  end
+
+  def admin?
+    !admin.nil?
   end
 end

--- a/app/views/api/sessions/create.json.jbuilder
+++ b/app/views/api/sessions/create.json.jbuilder
@@ -1,3 +1,9 @@
 # frozen_string_literal: true
 
 json.access_token @session.token.token
+
+json.user do
+  json.id @user.id
+  json.email @user.email
+  json.admin @user.admin?
+end

--- a/db/migrate/20170323121714_create_admins.rb
+++ b/db/migrate/20170323121714_create_admins.rb
@@ -1,0 +1,9 @@
+class CreateAdmins < ActiveRecord::Migration[5.0]
+  def change
+    create_table :admins do |t|
+      t.references :user, index: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170302105933) do
+ActiveRecord::Schema.define(version: 20170323121714) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,6 +19,13 @@ ActiveRecord::Schema.define(version: 20170302105933) do
     t.string   "name",       null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "admins", force: :cascade do |t|
+    t.integer  "user_id",    null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_admins_on_user_id", using: :btree
   end
 
   create_table "advertisements", force: :cascade do |t|

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -11,6 +11,8 @@ namespace :db do
       create_melody2
       create_appearances
       create_advertisements
+
+      puts "Create Anime { id: #{@anime.id}, title: #{@anime.title}}"
     end
   end
 end

--- a/spec/factories/admins.rb
+++ b/spec/factories/admins.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryGirl.define do
+  factory :admin do
+    user
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -10,5 +10,8 @@ FactoryGirl.define do
       status :registered
     end
     password 'password'
+    trait :admin_user do
+      admin
+    end
   end
 end

--- a/spec/models/admin_spec.rb
+++ b/spec/models/admin_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Admin, type: :model do
+  it { is_expected.to belong_to(:user) }
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,7 +3,23 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
+  it { is_expected.to have_one(:admin) }
+
   describe 'バリデーション' do
     it { is_expected.to validate_presence_of(:email) }
+  end
+
+  describe '#admin?' do
+    context 'user is admin' do
+      subject { create(:user, :admin_user).admin? }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context 'user is not admin' do
+      subject { create(:user).admin? }
+
+      it { is_expected.to be_falsey }
+    end
   end
 end

--- a/spec/requests/login_spec.rb
+++ b/spec/requests/login_spec.rb
@@ -17,6 +17,15 @@ describe 'POST /api/session?email=email&password=password', autodoc: true do
       post '/api/session', params: params
       expect(response.status).to eq 200
       expect(JSON.parse(response.body)['access_token']).to be_a(String)
+
+      json = {
+        user: {
+          id: user.id,
+          email: email,
+          admin: false
+        }
+      }
+      expect(response.body).to be_json_including(json)
     end
   end
 


### PR DESCRIPTION
## 対応内容

- 管理者用のモデルを追加
- ログインapiで返すレスポンスにユーザ情報を追加
- seedで流した際に、`puts`で標準出力
- specを追加