### PR TITLE
ユーザ情報を返すAPIを追加

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -283,7 +283,7 @@ GEM
       rspec-mocks (~> 3.5.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    rubocop (0.48.0)
+    rubocop (0.48.1)
       parser (>= 2.3.3.1, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)

--- a/app/controllers/admin/melodies_controller.rb
+++ b/app/controllers/admin/melodies_controller.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 class Admin::MelodiesController < Admin::BaseController
-  before_action :set_melody, only: %i(show edit update destroy)
-  before_action :set_animes, only: %i(new create edit update)
-  before_action :set_seasons, only: %i(new create edit update)
-  before_action :set_singers, only: %i(new create edit update)
+  before_action :set_melody, only: %i[show edit update destroy]
+  before_action :set_animes, only: %i[new create edit update]
+  before_action :set_seasons, only: %i[new create edit update]
+  before_action :set_singers, only: %i[new create edit update]
 
   def index
     @singers = Singer.all

--- a/app/controllers/api/admin/actors_controller.rb
+++ b/app/controllers/api/admin/actors_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-class Api::Admin::ActorsController < Api::BaseController
-  before_action :set_actor, only: %i(show update destroy)
+class Api::Admin::ActorsController < Api::Admin::BaseController
+  before_action :set_actor, only: %i[show update destroy]
 
   def index
     @actors = Actor.order(created_at: :desc)

--- a/app/controllers/api/admin/animes_controller.rb
+++ b/app/controllers/api/admin/animes_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-class Api::Admin::AnimesController < Api::BaseController
-  before_action :set_anime, only: %i(show update destroy)
+class Api::Admin::AnimesController < Api::Admin::BaseController
+  before_action :set_anime, only: %i[show update destroy]
 
   def index
     @animes = Anime.all.order(created_at: :desc)

--- a/app/controllers/api/admin/base_controller.rb
+++ b/app/controllers/api/admin/base_controller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Api::Admin::BaseController < Api::BaseController
+end

--- a/app/controllers/api/admin/seasons_controller.rb
+++ b/app/controllers/api/admin/seasons_controller.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-class Api::Admin::SeasonsController < Api::BaseController
-  before_action :set_anime, only: %i(index show create update destroy)
-  before_action :set_season, only: %i(update show destroy)
+class Api::Admin::SeasonsController < Api::Admin::BaseController
+  before_action :set_anime, only: %i[index show create update destroy]
+  before_action :set_season, only: %i[update show destroy]
 
   def index
     @seasons = @anime.seasons.order(phase: :desc)

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Api::UsersController < Api::BaseController
+  before_action :authenticate
+
+  def show
+    @user = current_user
+  end
+end

--- a/app/models/melody.rb
+++ b/app/models/melody.rb
@@ -7,5 +7,5 @@ class Melody < ApplicationRecord
 
   validates :title, :kind, presence: true
 
-  enum kind: %i(op ed)
+  enum kind: %i[op ed]
 end

--- a/app/views/api/users/show.json.jbuilder
+++ b/app/views/api/users/show.json.jbuilder
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+json.email @user.email
+json.admin @user.admin?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   end
 
   namespace :api, only: %i(index), format: 'json' do
+    resource :user, only: %i(show)
     resource :session, only: %i(create)
     resources :animes, only: %i(index)
 

--- a/lib/brakeman_report.rb
+++ b/lib/brakeman_report.rb
@@ -59,7 +59,7 @@ class BrakemanReport
   end
 
   def test_count
-    numbers = %w(number_of_controllers number_of_models number_of_templates)
+    numbers = %w[number_of_controllers number_of_models number_of_templates]
     numbers.inject(0) do |sum, key|
       sum + json['scan_info'][key]
     end

--- a/spec/factories/melodies.rb
+++ b/spec/factories/melodies.rb
@@ -4,7 +4,7 @@ FactoryGirl.define do
   factory :melody do
     anime
     season
-    kind { %i(op ed).sample }
+    kind { %i[op ed].sample }
     sequence(:title) { |n| "曲名タイトル#{n}" }
     singer
     # TODO: 音楽データを設定する

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -50,6 +50,7 @@ RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
   config.include RSpec::JsonMatcher
   config.include ActiveJob::TestHelper
+  config.include RequestSpecHelper, type: :request
 
   config.before :suite do
     I18n.locale = :ja
@@ -70,11 +71,11 @@ RSpec.configure do |config|
       File.expand_path('../autodoc/templates/document.md.erb', __FILE__)
     )
   Autodoc.configuration.suppressed_request_header =
-    %w(Accept Content-Length Host)
+    %w[Accept Content-Length Host]
   Autodoc.configuration.suppressed_response_header =
-    %w(
+    %w[
       Cache-Control Content-Length ETag
       X-Content-Type-Options X-Frame-Options X-Request-Id
       X-Runtime X-XSS-Protection
-    )
+    ]
 end

--- a/spec/requests/login_spec.rb
+++ b/spec/requests/login_spec.rb
@@ -97,7 +97,7 @@ describe 'POST /api/session?email=email&password=password', autodoc: true do
 
       expect(response.status).to eq 401
       json = {
-        error_messages: %w(メールアドレスを入力してください パスワードを入力してください)
+        error_messages: %w[メールアドレスを入力してください パスワードを入力してください]
       }
       expect(response.body).to be_json_as(json)
     end

--- a/spec/requests/user_spec.rb
+++ b/spec/requests/user_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'GET /api/user', autodoc: true do
+  let(:email) { 'user@example.com' }
+
+  context 'ログインしていない場合' do
+    it '401が返ってくること' do
+      get '/api/user'
+      expect(response.status).to eq 401
+    end
+  end
+
+  context '一般ユーザーでログインしている場合' do
+    let!(:user) { create(:user, :registered, email: email) }
+
+    it '200とログインユーザの情報が返ってくること' do
+      get '/api/user', headers: login_headers(user)
+      expect(response.status).to eq 200
+
+      json = {
+        email: email,
+        admin: false
+      }
+      expect(response.body).to be_json_as(json)
+    end
+  end
+
+  context '管理者ユーザーでログインしている場合' do
+    let!(:user) { create(:user, :registered, :admin_user, email: email) }
+
+    it '200とログインユーザの情報が返ってくること' do
+      get '/api/user', headers: login_headers(user)
+      expect(response.status).to eq 200
+
+      json = {
+        email: email,
+        admin: true
+      }
+      expect(response.body).to be_json_as(json)
+    end
+  end
+end

--- a/spec/support/request_spec_helper.rb
+++ b/spec/support/request_spec_helper.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module RequestSpecHelper
+  def login_headers(user)
+    valid_token = user.find_token_by_name(:access)
+    valid_token ||= user.add_access_token
+    { Authorization: ActionController::HttpAuthentication::Token\
+      .encode_credentials(valid_token.token) }
+  end
+end


### PR DESCRIPTION
## 対応内容

- ユーザー情報を返すAPIを追加しました
- rubocopを`0.48.1`にアップデートしました（バグを踏んだので）
- rubocopの自動変換で修正しました
- apiのadminの親controllerを追加しました
- specの認証モジュールを追加しました