### PR TITLE
管理画面：アニメに広告を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'rails', '5.0.2'
 gem 'activemodel-serializers-xml', github: 'rails/activemodel-serializers-xml' # for draper
 gem 'bcrypt'
 gem 'bootstrap-sass'
-gem 'draper', github: 'audionerd/draper', branch: 'rails5'
+gem 'draper', '> 3.x'
 gem 'exception_notification'
 gem 'pg', '~> 0.18'
 gem 'puma', '~> 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,4 @@
 GIT
-  remote: git://github.com/audionerd/draper.git
-  revision: e816e0e5876b76c648c0928f1c3f2aa2c7a3d1f2
-  branch: rails5
-  specs:
-    draper (2.1.0)
-      actionpack (>= 3.0)
-      activemodel (>= 3.0)
-      activesupport (>= 3.0)
-      request_store (~> 1.0)
-
-GIT
   remote: git://github.com/rails/activemodel-serializers-xml.git
   revision: dd9c0acf26aab111ebc647cd8deb99ebc6946531
   specs:
@@ -112,6 +101,12 @@ GEM
     dotenv-rails (2.2.0)
       dotenv (= 2.2.0)
       railties (>= 3.2, < 5.1)
+    draper (3.0.0.pre1)
+      actionpack (~> 5.0)
+      activemodel (~> 5.0)
+      activemodel-serializers-xml (~> 1.0)
+      activesupport (~> 5.0)
+      request_store (~> 1.0)
     erubis (2.7.0)
     eventmachine (1.2.3)
     exception_notification (4.2.1)
@@ -375,7 +370,7 @@ DEPENDENCIES
   capybara-screenshot
   database_rewinder
   dotenv-rails
-  draper!
+  draper (> 3.x)
   exception_notification
   factory_girl_rails
   faker

--- a/app/assets/javascripts/__tests__/admin/animes/detail/_admin_anime_detail.test.js
+++ b/app/assets/javascripts/__tests__/admin/animes/detail/_admin_anime_detail.test.js
@@ -11,6 +11,7 @@ import AdminAnimeDetail from '../../../../components/admin/animes/detail/_admin_
 import AdminAnimeTitle from '../../../../components/admin/animes/detail/_admin_anime_title'
 import AdminAnimeThumbnail from '../../../../components/admin/animes/detail/_admin_anime_thumbnail'
 import AdminAnimeBody from '../../../../components/admin/animes/detail/_admin_anime_body'
+import AdminAnimeAdvertisements from '../../../../components/admin/animes/detail/advertisements/_admin_anime_advertisements'
 jest.unmock('../../../../components/admin/animes/detail/_admin_anime_detail')
 
 describe('AdminAnimeDetailComponent', () => {
@@ -34,6 +35,8 @@ describe('AdminAnimeDetailComponent', () => {
                 <AdminAnimeBody handleUpdateBody={jest.fn()} ref='body' summary='アニメサマリ' wiki_url='https://wiki.com' />
               </div>
             </div>
+            <hr />
+            <AdminAnimeAdvertisements anime_id='1' />
           </div>
         </div>
       </div>

--- a/app/assets/javascripts/components/admin/animes/detail/_admin_anime_detail.js
+++ b/app/assets/javascripts/components/admin/animes/detail/_admin_anime_detail.js
@@ -4,6 +4,7 @@ import { origin } from './../../../../origin.js'
 import AdminAnimeTitle from './_admin_anime_title'
 import AdminAnimeThumbnail from './_admin_anime_thumbnail'
 import AdminAnimeBody from './_admin_anime_body'
+import AdminAnimeAdvertisements from './advertisements/_admin_anime_advertisements'
 
 export default class AdminAnimeDetail extends Component {
   constructor(props) {
@@ -86,6 +87,8 @@ export default class AdminAnimeDetail extends Component {
                 <AdminAnimeBody handleUpdateBody={this.onSubmit} ref='body' summary={this.state.anime.summary} wiki_url={this.state.anime.wiki_url} />
               </div>
             </div>
+            <hr />
+            <AdminAnimeAdvertisements anime_id={this.props.anime_id} />
           </div>
         </div>
       </div>

--- a/app/assets/javascripts/components/admin/animes/detail/advertisements/_admin_advertisement_form.js
+++ b/app/assets/javascripts/components/admin/animes/detail/advertisements/_admin_advertisement_form.js
@@ -6,19 +6,11 @@ export default class AdminAdvertisementForm extends Component {
     super(props)
     this.state = {
       loadingForm: false,
-      unsaved_start_on: '',
-      unsaved_end_on: '',
-      unsaved_phase: '',
-      unsaved_name: '',
       message_type: 'danger',
       message: ''
     }
     this.handleClickCancelButton = this.handleClickCancelButton.bind(this)
     this.handleClickSubmitButton = this.handleClickSubmitButton.bind(this)
-    this.handleChangeStartOn = this.handleChangeStartOn.bind(this)
-    this.handleChangeEndOn = this.handleChangeEndOn.bind(this)
-    this.handleChangePhase = this.handleChangePhase.bind(this)
-    this.handleChangeName = this.handleChangeName.bind(this)
     this.handleTimeout = this.handleTimeout.bind(this)
     this.updateFailed = this.updateFailed.bind(this)
   }
@@ -31,22 +23,6 @@ export default class AdminAdvertisementForm extends Component {
     this.setState({loadingForm: true})
     const body = this.refs.body.value
     this.props.onSubmit(body)
-  }
-
-  handleChangeStartOn(e) {
-    this.setState({unsaved_start_on: e.target.value})
-  }
-
-  handleChangeEndOn(e) {
-    this.setState({unsaved_end_on: e.target.value})
-  }
-
-  handleChangePhase(e) {
-    this.setState({unsaved_phase: e.target.value})
-  }
-
-  handleChangeName(e) {
-    this.setState({unsaved_name: e.target.value})
   }
 
   handleTimeout() {

--- a/app/assets/javascripts/components/admin/animes/detail/advertisements/_admin_advertisement_form.js
+++ b/app/assets/javascripts/components/admin/animes/detail/advertisements/_admin_advertisement_form.js
@@ -1,0 +1,91 @@
+import React, { Component, PropTypes } from 'react'
+import MessageBox from './../../../../common/_message_box'
+
+export default class AdminAdvertisementForm extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      loadingForm: false,
+      unsaved_start_on: '',
+      unsaved_end_on: '',
+      unsaved_phase: '',
+      unsaved_name: '',
+      message_type: 'danger',
+      message: ''
+    }
+    this.handleClickCancelButton = this.handleClickCancelButton.bind(this)
+    this.handleClickSubmitButton = this.handleClickSubmitButton.bind(this)
+    this.handleChangeStartOn = this.handleChangeStartOn.bind(this)
+    this.handleChangeEndOn = this.handleChangeEndOn.bind(this)
+    this.handleChangePhase = this.handleChangePhase.bind(this)
+    this.handleChangeName = this.handleChangeName.bind(this)
+    this.handleTimeout = this.handleTimeout.bind(this)
+    this.updateFailed = this.updateFailed.bind(this)
+  }
+
+  handleClickCancelButton() {
+    this.props.onClose()
+  }
+
+  handleClickSubmitButton() {
+    this.setState({loadingForm: true})
+    const body = this.refs.body.value
+    this.props.onSubmit(body)
+  }
+
+  handleChangeStartOn(e) {
+    this.setState({unsaved_start_on: e.target.value})
+  }
+
+  handleChangeEndOn(e) {
+    this.setState({unsaved_end_on: e.target.value})
+  }
+
+  handleChangePhase(e) {
+    this.setState({unsaved_phase: e.target.value})
+  }
+
+  handleChangeName(e) {
+    this.setState({unsaved_name: e.target.value})
+  }
+
+  handleTimeout() {
+    this.setState({message: ''})
+  }
+
+  updateFailed(message) {
+    this.setState({
+      loadingForm: false,
+      message_type: 'danger',
+      message: message
+    })
+    setTimeout(this.handleTimeout, 2000)
+  }
+
+  render() {
+    return (
+      <div className='adminAdvertisementFormComponent'>
+        <form className='form-inline' onSubmit={this.handleClickSubmitButton}>
+          <div className='form-group body'>
+            <textarea className='form-control' defaultValue={(this.props.advertisement || {}).body} disabled={this.state.loadingForm} id='body' placeholder='htmlタグ' ref='body' rows='4' cols='120' />
+          </div>
+          <div className='submit-button-field'>
+            <a className='btn btn-danger animate-button' disabled={this.state.loadingForm} onClick={this.handleClickSubmitButton}>
+              {this.props.melody ? '更新' : '登録'}
+            </a>
+            <a className='btn btn-default cancel-button' disabled={this.state.loadingForm} onClick={this.handleClickCancelButton}>
+              {'キャンセル'}
+            </a>
+            <MessageBox message={this.state.message} message_type={this.state.message_type} />
+          </div>
+        </form>
+      </div>
+    )
+  }
+}
+
+AdminAdvertisementForm.propTypes = {
+  advertisement: PropTypes.object,
+  onClose: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired
+}

--- a/app/assets/javascripts/components/admin/animes/detail/advertisements/_admin_advertisement_form.js
+++ b/app/assets/javascripts/components/admin/animes/detail/advertisements/_admin_advertisement_form.js
@@ -43,11 +43,11 @@ export default class AdminAdvertisementForm extends Component {
       <div className='adminAdvertisementFormComponent'>
         <form className='form-inline' onSubmit={this.handleClickSubmitButton}>
           <div className='form-group body'>
-            <textarea className='form-control' defaultValue={(this.props.advertisement || {}).body} disabled={this.state.loadingForm} id='body' placeholder='htmlタグ' ref='body' rows='4' cols='120' />
+            <textarea className='form-control' cols='120' defaultValue={(this.props.advertisement || {}).body} disabled={this.state.loadingForm} id='body' placeholder='htmlタグ' ref='body' rows='4' />
           </div>
           <div className='submit-button-field'>
             <a className='btn btn-danger animate-button' disabled={this.state.loadingForm} onClick={this.handleClickSubmitButton}>
-              {this.props.melody ? '更新' : '登録'}
+              {this.props.advertisement ? '更新' : '登録'}
             </a>
             <a className='btn btn-default cancel-button' disabled={this.state.loadingForm} onClick={this.handleClickCancelButton}>
               {'キャンセル'}

--- a/app/assets/javascripts/components/admin/animes/detail/advertisements/_admin_anime_advertisement_new_field.js
+++ b/app/assets/javascripts/components/admin/animes/detail/advertisements/_admin_anime_advertisement_new_field.js
@@ -1,0 +1,87 @@
+import React, { Component, PropTypes } from 'react'
+import { origin } from './../../../../../origin'
+import AdminNewButtonField from './../../../_admin_new_button_field'
+import AdminAdvertisementForm from './_admin_advertisement_form'
+
+export default class AdminAnimeAdvertisementNewField extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      showForm: false,
+      message_type: 'success',
+      message: ''
+    }
+    this.handleClickCancelButton = this.handleClickCancelButton.bind(this)
+    this.handleClickSubmitButton = this.handleClickSubmitButton.bind(this)
+    this.handleTimeout = this.handleTimeout.bind(this)
+    this.handleShowNewForm = this.handleShowNewForm.bind(this)
+    this.postAdvertisementAgainstServer = this.postAdvertisementAgainstServer.bind(this)
+  }
+
+  handleShowNewForm() {
+    this.setState({showForm: true})
+  }
+
+  handleClickCancelButton() {
+    this.setState({showForm: false})
+  }
+
+  handleTimeout() {
+    this.setState({message: ''})
+  }
+
+  handleClickSubmitButton(body) {
+    const params = { advertisement: {
+      anime_id: this.props.anime_id,
+      body: body
+    }}
+    this.postAdvertisementAgainstServer(params)
+  }
+
+  postAdvertisementAgainstServer(params) {
+    fetch(origin + 'api/admin/advertisements', {
+      method: 'POST',
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+        'Authorization': 'Token token=' + localStorage.getItem('access_token')
+      },
+      body: JSON.stringify(params)
+    })
+      .then((res) => {
+        if(res.status == '201') {
+          this.setState({
+            showForm: false,
+            message_type: 'success',
+            message: name + '登録しました'
+          })
+          setTimeout(this.handleTimeout, 2000)
+          //this.props.handleLoadSeasons()
+        } else {
+          res.json().then((json) => {
+            this.refs.form.updateFailed(json.error_messages[0])
+          })
+        }
+      })
+      .catch((error) => {
+        console.log(error)
+      })
+  }
+
+  render() {
+    return (
+      <div className='adminAnimeAdvertisementNewFieldComponent new-form-field'>
+        {this.state.showForm ? (
+          <AdminAdvertisementForm onClose={this.handleClickCancelButton} onSubmit={this.handleClickSubmitButton} ref='form' />
+          ) : (
+          <AdminNewButtonField message={this.state.message} message_type={this.state.message_type} name='Advertisement' onLoadNewForm={this.handleShowNewForm} />
+          )}
+      </div>
+    )
+  }
+}
+
+AdminAnimeAdvertisementNewField.propTypes = {
+  anime_id: PropTypes.string.isRequired
+  //handleLoadAdvertisements: PropTypes.func.isRequired
+}

--- a/app/assets/javascripts/components/admin/animes/detail/advertisements/_admin_anime_advertisement_new_field.js
+++ b/app/assets/javascripts/components/admin/animes/detail/advertisements/_admin_anime_advertisement_new_field.js
@@ -56,7 +56,7 @@ export default class AdminAnimeAdvertisementNewField extends Component {
             message: name + '登録しました'
           })
           setTimeout(this.handleTimeout, 2000)
-          //this.props.handleLoadSeasons()
+          //this.props.handleLoadAdvertisements()
         } else {
           res.json().then((json) => {
             this.refs.form.updateFailed(json.error_messages[0])

--- a/app/assets/javascripts/components/admin/animes/detail/advertisements/_admin_anime_advertisements.js
+++ b/app/assets/javascripts/components/admin/animes/detail/advertisements/_admin_anime_advertisements.js
@@ -1,5 +1,5 @@
 import React, { Component, PropTypes } from 'react'
-import { origin } from './../../../../../origin'
+//import { origin } from './../../../../../origin'
 import AdminAnimeAdvertisementNewField from './_admin_anime_advertisement_new_field'
 
 export default class AdminAnimeAdvertisements extends Component {
@@ -10,7 +10,7 @@ export default class AdminAnimeAdvertisements extends Component {
   render() {
     return (
       <div className='adminAnimeAdvertisementsComponent'>
-        <AdminAnimeAdvertisementNewField anime_id={this.props.anime_id} handleLoadSeasons={this.loadSeasonsFromServer} />
+        <AdminAnimeAdvertisementNewField anime_id={this.props.anime_id} handleLoadAdvertisements={this.loadAdvertisementsFromServer} />
       </div>
     )
   }

--- a/app/assets/javascripts/components/admin/animes/detail/advertisements/_admin_anime_advertisements.js
+++ b/app/assets/javascripts/components/admin/animes/detail/advertisements/_admin_anime_advertisements.js
@@ -1,0 +1,21 @@
+import React, { Component, PropTypes } from 'react'
+import { origin } from './../../../../../origin'
+import AdminAnimeAdvertisementNewField from './_admin_anime_advertisement_new_field'
+
+export default class AdminAnimeAdvertisements extends Component {
+  constructor(props) {
+    super(props)
+  }
+
+  render() {
+    return (
+      <div className='adminAnimeAdvertisementsComponent'>
+        <AdminAnimeAdvertisementNewField anime_id={this.props.anime_id} handleLoadSeasons={this.loadSeasonsFromServer} />
+      </div>
+    )
+  }
+}
+
+AdminAnimeAdvertisements.propTypes = {
+  anime_id: PropTypes.string.isRequired
+}

--- a/app/assets/javascripts/components/admin/animes/detail/seasons/melodies/_admin_anime_season_melodies.js
+++ b/app/assets/javascripts/components/admin/animes/detail/seasons/melodies/_admin_anime_season_melodies.js
@@ -61,13 +61,13 @@ export default class AdminAnimeSeasonMelodies extends Component {
   render() {
     return (
       <div className='adminAnimeSeasonMelodiesComponent'>
+        <AdminSeasonMelodyNewField handleLoadMelodies={this.loadMelodiesFromServer} season_id={this.props.season_id} />
         {this.state.melodies.map((melody) =>
           <AdminAnimeSeasonMelody key={melody.id} melody={melody} onShowEditMelodyField={this.handleShowEditMelodyField} />
         )}
         {this.state.melodies.map((melody) =>
           <AdminSeasonMelodyEditField handleLoadMelodies={this.loadMelodiesFromServer} key={melody.id} melody={melody} onCloseEditMelodyField={this.handleCloseEditMelodyField} />
         )}
-        <AdminSeasonMelodyNewField handleLoadMelodies={this.loadMelodiesFromServer} season_id={this.props.season_id} />
       </div>
     )
   }

--- a/app/assets/javascripts/components/admin/animes/detail/seasons/melodies/_admin_season_melody_edit_field.js
+++ b/app/assets/javascripts/components/admin/animes/detail/seasons/melodies/_admin_season_melody_edit_field.js
@@ -84,7 +84,7 @@ export default class AdminSeasonMelodyEditField extends Component {
     return (
       <div>
         {this.props.melody.showEditForm ? (
-          <div className='adminSeasonMelodyEditFieldComponent new-form-field'>
+          <div className='adminSeasonMelodyEditFieldComponent new-form-field media-body non-bordered'>
             <AdminSeasonMelodyForm melody={this.props.melody} onClose={this.handleClickCancelButton} onSubmit={this.handleClickSubmitButton} ref='form' season_id={this.props.melody.season_id} />
             <div className='pull-right'>
               <span className='link' onClick={this.handleClickTrashIcon}>

--- a/app/controllers/api/admin/advertisements_controller.rb
+++ b/app/controllers/api/admin/advertisements_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class Api::Admin::AdvertisementsController < Api::Admin::BaseController
+  def create
+    @advertisement = Advertisement.new(advertisement_params)
+    if @advertisement.save
+      head :created
+    else
+      render_error @advertisement
+    end
+  end
+
+  private
+
+  def advertisement_params
+    params.require(:advertisement)
+          .permit(:anime_id, :actor_id, :season_id, :body)
+  end
+end

--- a/app/models/actor.rb
+++ b/app/models/actor.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class Actor < ApplicationRecord
-  has_many :appearances
-  has_many :advertisements
+  has_many :appearances, dependent: :destroy
+  has_many :advertisements, dependent: :destroy
 
   validates :name, presence: true
 end

--- a/app/models/advertisement.rb
+++ b/app/models/advertisement.rb
@@ -3,6 +3,12 @@
 class Advertisement < ApplicationRecord
   belongs_to :anime, optional: true
   belongs_to :actor, optional: true
+  belongs_to :season, optional: true
 
   validates :body, presence: true
+  validate :should_have_id
+
+  def should_have_id
+    errors[:base] << '所属が不明な広告です' unless anime || season || actor
+  end
 end

--- a/app/models/anime.rb
+++ b/app/models/anime.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 class Anime < ApplicationRecord
-  has_many :seasons
-  has_many :melodies
-  has_many :appearances
-  has_many :advertisements
+  has_many :seasons, dependent: :destroy
+  has_many :melodies, dependent: :destroy
+  has_many :appearances, dependent: :destroy
+  has_many :advertisements, dependent: :destroy
 
   validates :title,
             presence: true,

--- a/app/models/season.rb
+++ b/app/models/season.rb
@@ -2,7 +2,7 @@
 
 class Season < ApplicationRecord
   belongs_to :anime
-  has_many :melodies
+  has_many :melodies, dependent: :destroy
 
   validates :phase,
             presence: true,

--- a/config/locales/activerecord_ja.yml
+++ b/config/locales/activerecord_ja.yml
@@ -1,6 +1,8 @@
 ja:
   activerecord:
     attributes:
+      advertisement:
+        body: htmlタグ
       anime:
         title: タイトル
         summary: あらすじ

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
     get :welcome, to: 'welcome#show'
 
     namespace :admin do
+      resources :advertisements, only: %i(create)
       resources :animes, only: %i(index show create update destroy) do
         resources :seasons, only: %i(index show create update destroy)
       end

--- a/db/migrate/20170429153601_add_season_id_to_advertisements.rb
+++ b/db/migrate/20170429153601_add_season_id_to_advertisements.rb
@@ -1,0 +1,5 @@
+class AddSeasonIdToAdvertisements < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :advertisements, :season, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170323121714) do
+ActiveRecord::Schema.define(version: 20170429153601) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,8 +34,10 @@ ActiveRecord::Schema.define(version: 20170323121714) do
     t.text     "body",       null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer  "season_id"
     t.index ["actor_id"], name: "index_advertisements_on_actor_id", using: :btree
     t.index ["anime_id"], name: "index_advertisements_on_anime_id", using: :btree
+    t.index ["season_id"], name: "index_advertisements_on_season_id", using: :btree
   end
 
   create_table "animes", force: :cascade do |t|
@@ -114,4 +116,5 @@ ActiveRecord::Schema.define(version: 20170323121714) do
     t.datetime "updated_at",      null: false
   end
 
+  add_foreign_key "advertisements", "seasons"
 end

--- a/spec/factories/advertisements.rb
+++ b/spec/factories/advertisements.rb
@@ -3,7 +3,14 @@
 FactoryGirl.define do
   factory :advertisement do
     anime
-    actor
+    trait :belongs_to_actor do
+      anime_id { nil }
+      actor
+    end
+    trait :belongs_to_season do
+      anime_id { nil }
+      season
+    end
     sequence(:body) { |n| "<a href='https://url.com'>#{n}</a>" }
   end
 end

--- a/spec/models/actor_spec.rb
+++ b/spec/models/actor_spec.rb
@@ -3,8 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe Actor, type: :model do
-  it { is_expected.to have_many(:appearances) }
-  it { is_expected.to have_many(:advertisements) }
+  it { is_expected.to have_many(:appearances).dependent(:destroy) }
+  it { is_expected.to have_many(:advertisements).dependent(:destroy) }
 
   describe 'バリデーション' do
     it { is_expected.to validate_presence_of(:name) }

--- a/spec/models/anime_spec.rb
+++ b/spec/models/anime_spec.rb
@@ -3,10 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe Anime, type: :model do
-  it { is_expected.to have_many(:seasons) }
-  it { is_expected.to have_many(:melodies) }
-  it { is_expected.to have_many(:appearances) }
-  it { is_expected.to have_many(:advertisements) }
+  it { is_expected.to have_many(:seasons).dependent(:destroy) }
+  it { is_expected.to have_many(:melodies).dependent(:destroy) }
+  it { is_expected.to have_many(:appearances).dependent(:destroy) }
+  it { is_expected.to have_many(:advertisements).dependent(:destroy) }
 
   describe 'バリデーション' do
     it { is_expected.to validate_presence_of(:title) }

--- a/spec/models/season_spec.rb
+++ b/spec/models/season_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Season, type: :model do
   it { is_expected.to belong_to(:anime) }
-  it { is_expected.to have_many(:melodies) }
+  it { is_expected.to have_many(:melodies).dependent(:destroy) }
 
   describe 'バリデーション' do
     subject { create(:season) }

--- a/spec/requests/admin/advertisements_spec.rb
+++ b/spec/requests/admin/advertisements_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'POST /api/admin/advertisements', autodoc: true do
+  context 'ログインしていない場合' do
+    it '401が返ってくること' do
+      post '/api/admin/advertisements'
+      expect(response.status).to eq 401
+    end
+  end
+
+  context 'ログインしている場合' do
+    let!(:user) { create(:user, :registered) }
+
+    context 'アニメに広告を追加した場合' do
+      let!(:anime) { create(:anime) }
+      let(:params) do
+        { advertisement: attributes_for(:advertisement, anime_id: anime.id) }
+      end
+
+      it '201が返ってくること' do
+        post '/api/admin/advertisements',
+             params: params, headers: login_headers(user)
+        expect(response.status).to eq 201
+      end
+    end
+
+    context '声優に広告を追加した場合' do
+      let!(:actor) { create(:actor) }
+      let(:params) do
+        {
+          advertisement:
+            attributes_for(:advertisement, anime_id: nil, actor_id: actor.id)
+        }
+      end
+
+      it '201が返ってくること' do
+        post '/api/admin/advertisements',
+             params: params, headers: login_headers(user)
+        expect(response.status).to eq 201
+      end
+    end
+
+    context 'シーズンに広告を追加した場合' do
+      let!(:season) { create(:season) }
+      let(:params) do
+        {
+          advertisement:
+            attributes_for(:advertisement, anime_id: nil, season_id: season.id)
+        }
+      end
+
+      it '201が返ってくること' do
+        post '/api/admin/advertisements',
+             params: params, headers: login_headers(user)
+        expect(response.status).to eq 201
+      end
+    end
+
+    context '紐づくidのない広告を追加した場合' do
+      let(:params) { { advertisement: attributes_for(:advertisement) } }
+
+      it '422とエラーメッセージが返ってくること' do
+        post '/api/admin/advertisements',
+             params: params, headers: login_headers(user)
+        expect(response.status).to eq 422
+
+        json = {
+          error_messages: ['所属が不明な広告です']
+        }
+        expect(response.body).to be_json_as(json)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 対応内容

- アニメに広告を追加できるようにしました（広告の表示は別PRにて行います。）
- draperを3.0以降のバージョンを指定するようにしました
- その他のモデルの`has_many`に`dependent`オプションを追加しました
- `advertisements`テーブルに`season_id`カラムを追加しました
- テストを修正、追加しました