### PR TITLE
Install react-test-renderer, and Fix to react-test-renderer/shallow

### DIFF
--- a/app/assets/javascripts/__tests__/_navbar.test.js
+++ b/app/assets/javascripts/__tests__/_navbar.test.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import expect from 'expect'
 import { Link } from 'react-router'
-import { createRenderer } from 'react-addons-test-utils'
+import { createRenderer } from 'react-test-renderer/shallow'
 import expectJSX from 'expect-jsx'
 
 expect.extend(expectJSX)

--- a/app/assets/javascripts/__tests__/admin/_admin_menu.test.js
+++ b/app/assets/javascripts/__tests__/admin/_admin_menu.test.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import expect from 'expect'
 import { Link } from 'react-router'
-import { createRenderer } from 'react-addons-test-utils'
+import { createRenderer } from 'react-test-renderer/shallow'
 import expectJSX from 'expect-jsx'
 
 expect.extend(expectJSX)

--- a/app/assets/javascripts/__tests__/admin/actors/admin_actors_page.test.js
+++ b/app/assets/javascripts/__tests__/admin/actors/admin_actors_page.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import expect from 'expect'
-import { createRenderer } from 'react-addons-test-utils'
+import { createRenderer } from 'react-test-renderer/shallow'
 import expectJSX from 'expect-jsx'
 
 expect.extend(expectJSX)

--- a/app/assets/javascripts/__tests__/admin/actors/detail/admin_actor.test.js
+++ b/app/assets/javascripts/__tests__/admin/actors/detail/admin_actor.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import expect from 'expect'
-import { createRenderer } from 'react-addons-test-utils'
+import { createRenderer } from 'react-test-renderer/shallow'
 import expectJSX from 'expect-jsx'
 
 expect.extend(expectJSX)

--- a/app/assets/javascripts/__tests__/admin/actors/list/_admin_actor_row.test.js
+++ b/app/assets/javascripts/__tests__/admin/actors/list/_admin_actor_row.test.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import expect from 'expect'
 import { Link } from 'react-router'
-import { createRenderer } from 'react-addons-test-utils'
+import { createRenderer } from 'react-test-renderer/shallow'
 import expectJSX from 'expect-jsx'
 
 expect.extend(expectJSX)

--- a/app/assets/javascripts/__tests__/admin/actors/list/admin_actors.test.js
+++ b/app/assets/javascripts/__tests__/admin/actors/list/admin_actors.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import expect from 'expect'
-import { createRenderer } from 'react-addons-test-utils'
+import { createRenderer } from 'react-test-renderer/shallow'
 import expectJSX from 'expect-jsx'
 
 expect.extend(expectJSX)

--- a/app/assets/javascripts/__tests__/admin/admin.test.js
+++ b/app/assets/javascripts/__tests__/admin/admin.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import expect from 'expect'
-import { createRenderer } from 'react-addons-test-utils'
+import { createRenderer } from 'react-test-renderer/shallow'
 import expectJSX from 'expect-jsx'
 
 expect.extend(expectJSX)

--- a/app/assets/javascripts/__tests__/admin/animes/admin_animes_page.test.js
+++ b/app/assets/javascripts/__tests__/admin/animes/admin_animes_page.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import expect from 'expect'
-import { createRenderer } from 'react-addons-test-utils'
+import { createRenderer } from 'react-test-renderer/shallow'
 import expectJSX from 'expect-jsx'
 
 expect.extend(expectJSX)

--- a/app/assets/javascripts/__tests__/admin/animes/detail/_admin_anime_body.test.js
+++ b/app/assets/javascripts/__tests__/admin/animes/detail/_admin_anime_body.test.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import expect from 'expect'
-import { Simulate, createRenderer, renderIntoDocument, findRenderedDOMComponentWithClass } from 'react-addons-test-utils'
+import { Simulate, renderIntoDocument, findRenderedDOMComponentWithClass } from 'react-addons-test-utils'
+import { createRenderer } from 'react-test-renderer/shallow'
 import expectJSX from 'expect-jsx'
 import 'jest-fetch-mock'
 

--- a/app/assets/javascripts/__tests__/admin/animes/detail/_admin_anime_title.test.js
+++ b/app/assets/javascripts/__tests__/admin/animes/detail/_admin_anime_title.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import expect from 'expect'
-import { createRenderer } from 'react-addons-test-utils'
+import { createRenderer } from 'react-test-renderer/shallow'
 import expectJSX from 'expect-jsx'
 import 'jest-fetch-mock'
 

--- a/app/assets/javascripts/__tests__/admin/animes/detail/admin_anime.test.js
+++ b/app/assets/javascripts/__tests__/admin/animes/detail/admin_anime.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import expect from 'expect'
-import { createRenderer } from 'react-addons-test-utils'
+import { createRenderer } from 'react-test-renderer/shallow'
 import expectJSX from 'expect-jsx'
 
 expect.extend(expectJSX)

--- a/app/assets/javascripts/__tests__/admin/animes/list/admin_animes.test.js
+++ b/app/assets/javascripts/__tests__/admin/animes/list/admin_animes.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import expect from 'expect'
-import { createRenderer } from 'react-addons-test-utils'
+import { createRenderer } from 'react-test-renderer/shallow'
 import expectJSX from 'expect-jsx'
 
 expect.extend(expectJSX)

--- a/app/assets/javascripts/__tests__/admin/top/admin_top_page.test.js
+++ b/app/assets/javascripts/__tests__/admin/top/admin_top_page.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import expect from 'expect'
-import { createRenderer } from 'react-addons-test-utils'
+import { createRenderer } from 'react-test-renderer/shallow'
 import expectJSX from 'expect-jsx'
 
 expect.extend(expectJSX)

--- a/app/assets/javascripts/__tests__/common/_loading_image.test.js
+++ b/app/assets/javascripts/__tests__/common/_loading_image.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import expect from 'expect'
-import { createRenderer } from 'react-addons-test-utils'
+import { createRenderer } from 'react-test-renderer/shallow'
 import expectJSX from 'expect-jsx'
 
 expect.extend(expectJSX)

--- a/app/assets/javascripts/__tests__/common/_message_box.test.js
+++ b/app/assets/javascripts/__tests__/common/_message_box.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import expect from 'expect'
-import { createRenderer } from 'react-addons-test-utils'
+import { createRenderer } from 'react-test-renderer/shallow'
 import expectJSX from 'expect-jsx'
 
 expect.extend(expectJSX)

--- a/app/assets/javascripts/__tests__/welcome/_anime.test.js
+++ b/app/assets/javascripts/__tests__/welcome/_anime.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import expect from 'expect'
-import { createRenderer } from 'react-addons-test-utils'
+import { createRenderer } from 'react-test-renderer/shallow'
 import expectJSX from 'expect-jsx'
 
 expect.extend(expectJSX)

--- a/app/assets/javascripts/__tests__/welcome/welcome.test.js
+++ b/app/assets/javascripts/__tests__/welcome/welcome.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import expect from 'expect'
-import { createRenderer } from 'react-addons-test-utils'
+import { createRenderer } from 'react-test-renderer/shallow'
 import expectJSX from 'expect-jsx'
 
 expect.extend(expectJSX)

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "react-dom": "^15.4.2",
     "react-element-to-jsx-string": "~6.3.0",
     "react-router": "~3.0.2",
+    "react-test-renderer": "^15.5.4",
     "reactify": "~1.1.1",
     "style-loader": "~0.17.0",
     "url-loader": "~0.5.8"


### PR DESCRIPTION
## 対応内容

#288 一部、warningsを解消

The exception is shallow rendering, which is not DOM-specific. The shallow renderer has been moved to react-test-renderer/shallow.

```js
// Before (15.4 and below)
import { createRenderer } from 'react-addons-test-utils';

// After (15.5)
import { createRenderer } from 'react-test-renderer/shallow';
```
