### PR TITLE
シーズンの作成日時が同じ場合、idの降順にする

### DIFF
--- a/app/models/anime.rb
+++ b/app/models/anime.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class Anime < ApplicationRecord
-  has_many :seasons, -> { order(created_at: :desc, id: :desc) }, dependent: :destroy
+  has_many :seasons, -> { order(created_at: :desc, id: :desc) },
+           dependent: :destroy
   has_many :melodies, dependent: :destroy
   has_many :appearances, dependent: :destroy
   has_many :advertisements, dependent: :destroy

--- a/app/models/anime.rb
+++ b/app/models/anime.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Anime < ApplicationRecord
-  has_many :seasons, dependent: :destroy
+  has_many :seasons, -> { order(created_at: :asc, id: :asc) }, dependent: :destroy
   has_many :melodies, dependent: :destroy
   has_many :appearances, dependent: :destroy
   has_many :advertisements, dependent: :destroy

--- a/app/models/anime.rb
+++ b/app/models/anime.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Anime < ApplicationRecord
-  has_many :seasons, -> { order(created_at: :asc, id: :asc) }, dependent: :destroy
+  has_many :seasons, -> { order(created_at: :desc, id: :desc) }, dependent: :destroy
   has_many :melodies, dependent: :destroy
   has_many :appearances, dependent: :destroy
   has_many :advertisements, dependent: :destroy


### PR DESCRIPTION
## 対応内容

シーズンの表示順を作成日時とidの降順に固定しました

## 対応理由

シーズンの作成日時が同じ場合にidの昇順になっているために、テストが落ちる場合がある。
