### PR TITLE
広告の表示場所の変更

### DIFF
--- a/app/assets/javascripts/__tests__/welcome/_anime.test.js
+++ b/app/assets/javascripts/__tests__/welcome/_anime.test.js
@@ -36,7 +36,10 @@ describe('AnimeComponent', () => {
                 {'アニメサマリ'}
               </p>
               <p className='pull-right'>
-                <span className='label label-default link' onClick={jest.fn()}>{'PR'}</span>
+                <span className='label label-default link' onClick={jest.fn()}>
+                  {'PR'}
+                  <span className='glyphicon glyphicon-refresh' />
+                </span>
               </p>
             </div>
             <hr className='clear' />

--- a/app/assets/javascripts/__tests__/welcome/_anime.test.js
+++ b/app/assets/javascripts/__tests__/welcome/_anime.test.js
@@ -7,7 +7,6 @@ expect.extend(expectJSX)
 
 import Anime from '../../components/welcome/_anime'
 import Melody from '../../components/welcome/_melody'
-import Advertisements from '../../components/welcome/_advertisements'
 jest.unmock('../../components/welcome/_anime')
 
 describe('AnimeComponent', () => {
@@ -36,10 +35,12 @@ describe('AnimeComponent', () => {
               <p className='summary'>
                 {'アニメサマリ'}
               </p>
+              <p className='pull-right'>
+                <span className='label label-default link' onClick={jest.fn()}>{'PR'}</span>
+              </p>
             </div>
             <hr className='clear' />
             <Melody melody={melody} />
-            <Advertisements advertisements={[advertisement]} season_id={1} />
           </div>
         </div>
       </div>

--- a/app/assets/javascripts/__tests__/welcome/_anime_list.test.js
+++ b/app/assets/javascripts/__tests__/welcome/_anime_list.test.js
@@ -25,8 +25,8 @@ describe('AnimeListComponent', () => {
     let actualElement = component.single(reactElementToJSXString)
     let expectedElement = (
       <div className='animeListComponent'>
-        <Anime handleDisplayAdvertisements={jest.fn()} season={season1} />
-        <Anime handleDisplayAdvertisements={jest.fn()} season={season2} />
+        <Anime onDisplayAdvertisements={jest.fn()} season={season1} />
+        <Anime onDisplayAdvertisements={jest.fn()} season={season2} />
       </div>
     )
     expect(actualElement).toEqualJSX(expectedElement)

--- a/app/assets/javascripts/__tests__/welcome/_anime_list.test.js
+++ b/app/assets/javascripts/__tests__/welcome/_anime_list.test.js
@@ -25,8 +25,8 @@ describe('AnimeListComponent', () => {
     let actualElement = component.single(reactElementToJSXString)
     let expectedElement = (
       <div className='animeListComponent'>
-        <Anime season={season1} />
-        <Anime season={season2} />
+        <Anime handleDisplayAdvertisements={jest.fn()} season={season1} />
+        <Anime handleDisplayAdvertisements={jest.fn()} season={season2} />
       </div>
     )
     expect(actualElement).toEqualJSX(expectedElement)

--- a/app/assets/javascripts/__tests__/welcome/welcome.test.js
+++ b/app/assets/javascripts/__tests__/welcome/welcome.test.js
@@ -23,7 +23,7 @@ describe('WelcomeComponent', () => {
       <div className='welcomeComponent'>
         <h1>{'放送中のアニメ'}</h1>
         <div className='col-md-9'>
-          <AnimeList handleDisplayAdvertisements={jest.fn()} />
+          <AnimeList onDisplayAdvertisements={jest.fn()} />
         </div>
         <div className='col-md-3'>
           <div className="clear" />

--- a/app/assets/javascripts/__tests__/welcome/welcome.test.js
+++ b/app/assets/javascripts/__tests__/welcome/welcome.test.js
@@ -2,11 +2,13 @@ import React from 'react'
 import expect from 'expect'
 import { createRenderer } from 'react-test-renderer/shallow'
 import expectJSX from 'expect-jsx'
+import 'jest-fetch-mock'
 
 expect.extend(expectJSX)
 
 import Welcome from '../../components/welcome/welcome'
 import AnimeList from '../../components/welcome/_anime_list'
+import Tweets from '../../components/menu/_tweets'
 jest.unmock('../../components/welcome/welcome')
 
 describe('WelcomeComponent', () => {
@@ -21,12 +23,11 @@ describe('WelcomeComponent', () => {
       <div className='welcomeComponent'>
         <h1>{'放送中のアニメ'}</h1>
         <div className='col-md-9'>
-          <AnimeList />
+          <AnimeList handleDisplayAdvertisements={jest.fn()} />
         </div>
-        <div className='col-md-3 twitter-widget'>
-          <div className='panel panel-default'>
-            <a className='twitter-timeline' data-width='500' href='https://twitter.com/anison_time'>{'Tweets by anison_time'}</a>
-          </div>
+        <div className='col-md-3'>
+          <div className="clear" />
+          <Tweets />
         </div>
       </div>
     )

--- a/app/assets/javascripts/components/menu/_advertisement.js
+++ b/app/assets/javascripts/components/menu/_advertisement.js
@@ -3,7 +3,7 @@ import React, { Component, PropTypes } from 'react'
 export default class Advertisement extends Component {
   render () {
     return (
-      <div className='advertisementComponent' id={'advertisement-' + this.props.advertisement.melody_id}>
+      <div className='advertisementComponent' id={'advertisement-' + this.props.advertisement.id}>
         <span dangerouslySetInnerHTML={{__html: this.props.advertisement.body}} />
       </div>
     )

--- a/app/assets/javascripts/components/menu/_advertisements.js
+++ b/app/assets/javascripts/components/menu/_advertisements.js
@@ -27,6 +27,7 @@ export default class Advertisements extends Component {
     return (
       <div className='advertisementsComponent'>
         <div className='panel panel-default'>
+          <p className='menu-title'>{'おすすめPR'}</p>
           {this.props.advertisements.map((advertisement) =>
             <Advertisement advertisement={advertisement} key={advertisement.id} />
           )}

--- a/app/assets/javascripts/components/menu/_advertisements.js
+++ b/app/assets/javascripts/components/menu/_advertisements.js
@@ -5,9 +5,6 @@ import { origin } from './../../origin.js'
 export default class Advertisements extends Component {
   constructor(props) {
     super(props)
-    this.state = {
-      advertisements: this.props.advertisements
-    }
     this.handleRefreshAdvertisements = this.handleRefreshAdvertisements.bind(this)
   }
 
@@ -28,24 +25,12 @@ export default class Advertisements extends Component {
 
   render () {
     return (
-      <div className='advertisementsComponent clear'>
-        {this.props.advertisements.length > 0 ? (
-          <div>
-            <span className='label label-default'>{'PR'}</span>
-          </div>
-        ) : (
-          null
-        )}
-        {this.state.advertisements.map((advertisement) =>
-          <Advertisement advertisement={advertisement} key={advertisement.id} />
-        )}
-        {this.props.advertisements.length > 0 ? (
-          <div className='refresh-field'>
-            <span className='pull-right link glyphicon glyphicon-refresh' onClick={this.handleRefreshAdvertisements} />
-          </div>
-        ) : (
-          null
-        )}
+      <div className='advertisementsComponent'>
+        <div className='panel panel-default'>
+          {this.props.advertisements.map((advertisement) =>
+            <Advertisement advertisement={advertisement} key={advertisement.id} />
+          )}
+        </div>
       </div>
     )
   }
@@ -53,6 +38,5 @@ export default class Advertisements extends Component {
 
 Advertisements.propTypes = {
   advertisements: PropTypes.array.isRequired,
-  season_id: PropTypes.number.isRequired
-
+  season_id: PropTypes.number
 }

--- a/app/assets/javascripts/components/menu/_advertisements.js
+++ b/app/assets/javascripts/components/menu/_advertisements.js
@@ -5,22 +5,6 @@ import { origin } from './../../origin.js'
 export default class Advertisements extends Component {
   constructor(props) {
     super(props)
-    this.handleRefreshAdvertisements = this.handleRefreshAdvertisements.bind(this)
-  }
-
-  handleRefreshAdvertisements() {
-    this.loadAdvertisementsFromServer()
-  }
-
-  loadAdvertisementsFromServer() {
-    fetch(origin + 'api/seasons/' + this.props.season_id + '/advertisements')
-      .then((res) => res.json())
-      .then((res) => {
-        this.setState({advertisements: res.advertisements})
-      })
-      .catch((error) => {
-        console.error(error)
-      })
   }
 
   render () {
@@ -38,6 +22,5 @@ export default class Advertisements extends Component {
 }
 
 Advertisements.propTypes = {
-  advertisements: PropTypes.array.isRequired,
-  season_id: PropTypes.number
+  advertisements: PropTypes.array.isRequired
 }

--- a/app/assets/javascripts/components/menu/_advertisements.js
+++ b/app/assets/javascripts/components/menu/_advertisements.js
@@ -1,6 +1,5 @@
 import React, { Component, PropTypes } from 'react'
 import Advertisement from './_advertisement'
-import { origin } from './../../origin.js'
 
 export default class Advertisements extends Component {
   constructor(props) {

--- a/app/assets/javascripts/components/menu/_tweets.js
+++ b/app/assets/javascripts/components/menu/_tweets.js
@@ -1,0 +1,21 @@
+import React, { Component } from 'react'
+
+export default class Tweets extends Component {
+  componentWillMount() {
+    const script = document.createElement('script')
+    script.src = 'https://platform.twitter.com/widgets.js'
+    script.async = true
+    script.charSet = 'utf-8'
+    document.body.appendChild(script)
+  }
+
+  render() {
+    return (
+      <div className='tweetsComponent twitter-widget'>
+        <div className='panel panel-default'>
+          <a className='twitter-timeline' data-width='500' href='https://twitter.com/anison_time'>{'Tweets by anison_time'}</a>
+        </div>
+      </div>
+    )
+  }
+}

--- a/app/assets/javascripts/components/welcome/_anime.js
+++ b/app/assets/javascripts/components/welcome/_anime.js
@@ -8,7 +8,7 @@ export default class Anime extends Component {
   }
 
   handleClickPR() {
-    this.props.handleDisplayAdvertisements(this.props.season.id)
+    this.props.onDisplayAdvertisements(this.props.season.id)
   }
 
   render () {
@@ -47,5 +47,5 @@ export default class Anime extends Component {
 
 Anime.propTypes = {
   season: PropTypes.object.isRequired,
-  handleDisplayAdvertisements: PropTypes.func.isRequired
+  onDisplayAdvertisements: PropTypes.func.isRequired
 }

--- a/app/assets/javascripts/components/welcome/_anime.js
+++ b/app/assets/javascripts/components/welcome/_anime.js
@@ -27,7 +27,10 @@ export default class Anime extends Component {
                 { this.props.season.anime.summary }
               </p>
               <p className='pull-right'>
-                <span className='label label-default link' onClick={this.handleClickPR}>{'PR'}</span>
+                <span className='label label-default link' onClick={this.handleClickPR}>
+                  {'PR'}
+                  <span className='glyphicon glyphicon-refresh' />
+                </span>
               </p>
             </div>
             {this.props.season.melodies.length > 0 ? (

--- a/app/assets/javascripts/components/welcome/_anime.js
+++ b/app/assets/javascripts/components/welcome/_anime.js
@@ -1,8 +1,16 @@
 import React, { Component, PropTypes } from 'react'
 import Melody from './_melody'
-import Advertisements from './_advertisements'
 
 export default class Anime extends Component {
+  constructor(props) {
+    super(props)
+    this.handleClickPR = this.handleClickPR.bind(this)
+  }
+
+  handleClickPR() {
+    this.props.handleDisplayAdvertisements(this.props.season.id)
+  }
+
   render () {
     return (
       <div className='animeComponent' id={'season-' + this.props.season.id}>
@@ -18,6 +26,9 @@ export default class Anime extends Component {
               <p className='summary'>
                 { this.props.season.anime.summary }
               </p>
+              <p className='pull-right'>
+                <span className='label label-default link' onClick={this.handleClickPR}>{'PR'}</span>
+              </p>
             </div>
             {this.props.season.melodies.length > 0 ? (
               <hr className='clear' />
@@ -27,7 +38,6 @@ export default class Anime extends Component {
             {this.props.season.melodies.map((melody) =>
               <Melody key={melody.id} melody={melody} />
             )}
-            <Advertisements advertisements={this.props.season.advertisements} season_id={this.props.season.id} />
           </div>
         </div>
       </div>
@@ -36,5 +46,6 @@ export default class Anime extends Component {
 }
 
 Anime.propTypes = {
-  season: PropTypes.object.isRequired
+  season: PropTypes.object.isRequired,
+  handleDisplayAdvertisements: PropTypes.func.isRequired
 }

--- a/app/assets/javascripts/components/welcome/_anime_list.js
+++ b/app/assets/javascripts/components/welcome/_anime_list.js
@@ -16,7 +16,7 @@ export default class AnimeList extends Component {
   }
 
   handleDisplayAdvertisements(season_id) {
-    this.props.handleDisplayAdvertisements(season_id)
+    this.props.onDisplayAdvertisements(season_id)
   }
 
   loadAnimesFromServer() {
@@ -34,7 +34,7 @@ export default class AnimeList extends Component {
     return (
       <div className='animeListComponent'>
         {this.state.seasons.map((season) =>
-          <Anime key={season.id} handleDisplayAdvertisements={this.handleDisplayAdvertisements} season={season} />
+          <Anime key={season.id} onDisplayAdvertisements={this.handleDisplayAdvertisements} season={season} />
         )}
       </div>
     )
@@ -42,5 +42,5 @@ export default class AnimeList extends Component {
 }
 
 AnimeList.propTypes = {
-  handleDisplayAdvertisements: PropTypes.func.isRequired
+  onDisplayAdvertisements: PropTypes.func.isRequired
 }

--- a/app/assets/javascripts/components/welcome/_anime_list.js
+++ b/app/assets/javascripts/components/welcome/_anime_list.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { Component, PropTypes } from 'react'
 import Anime from './_anime.js'
 import { origin } from './../../origin.js'
 
@@ -8,10 +8,15 @@ export default class AnimeList extends Component {
     this.state = {
       seasons: []
     }
+    this.handleDisplayAdvertisements = this.handleDisplayAdvertisements.bind(this)
   }
 
   componentDidMount() {
     this.loadAnimesFromServer()
+  }
+
+  handleDisplayAdvertisements(season_id) {
+    this.props.handleDisplayAdvertisements(season_id)
   }
 
   loadAnimesFromServer() {
@@ -29,9 +34,13 @@ export default class AnimeList extends Component {
     return (
       <div className='animeListComponent'>
         {this.state.seasons.map((season) =>
-          <Anime key={season.id} season={season} />
+          <Anime key={season.id} handleDisplayAdvertisements={this.handleDisplayAdvertisements} season={season} />
         )}
       </div>
     )
   }
+}
+
+AnimeList.propTypes = {
+  handleDisplayAdvertisements: PropTypes.func.isRequired
 }

--- a/app/assets/javascripts/components/welcome/welcome.js
+++ b/app/assets/javascripts/components/welcome/welcome.js
@@ -1,13 +1,46 @@
 import React, { Component } from 'react'
 import AnimeList from './_anime_list.js'
+import Tweets from './../menu/_tweets.js'
+import Advertisements from './../menu/_advertisements.js'
+import { origin } from './../../origin.js'
 
 export default class Welcome extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      advertisements: []
+    }
+    this.handleDisplayAdvertisements = this.handleDisplayAdvertisements.bind(this)
+  }
+
   componentWillMount() {
-    const script = document.createElement('script')
-    script.src = 'https://platform.twitter.com/widgets.js'
-    script.async = true
-    script.charSet = 'utf-8'
-    document.body.appendChild(script)
+    this.loadAdvertisementsBySeasonsFromServer() // TODO: 日付で取得できるようにする
+  }
+
+  handleDisplayAdvertisements(season_id) {
+    this.loadAdvertisementsBySeasonFromServer(season_id)
+  }
+
+  loadAdvertisementsBySeasonFromServer(season_id) {
+    fetch(origin + 'api/seasons/' + season_id + '/advertisements')
+      .then((res) => res.json())
+      .then((res) => {
+        this.setState({advertisements: res.advertisements})
+      })
+      .catch((error) => {
+        console.error(error)
+      })
+  }
+
+  loadAdvertisementsBySeasonsFromServer(season_id) {
+    fetch(origin + 'api/advertisements')
+      .then((res) => res.json())
+      .then((res) => {
+        this.setState({advertisements: res.advertisements})
+      })
+      .catch((error) => {
+        console.error(error)
+      })
   }
 
   render() {
@@ -15,12 +48,16 @@ export default class Welcome extends Component {
       <div className='welcomeComponent'>
         <h1>{'放送中のアニメ'}</h1>
         <div className='col-md-9'>
-          <AnimeList />
+          <AnimeList handleDisplayAdvertisements={this.handleDisplayAdvertisements} />
         </div>
-        <div className='col-md-3 twitter-widget'>
-          <div className='panel panel-default'>
-            <a className='twitter-timeline' data-width='500' href='https://twitter.com/anison_time'>{'Tweets by anison_time'}</a>
-          </div>
+        <div className='col-md-3'>
+          {this.state.advertisements.length > 0 ? (
+            <Advertisements advertisements={this.state.advertisements} />
+          ) : (
+            null
+          )}
+          <div className='clear' />
+          <Tweets />
         </div>
       </div>
     )

--- a/app/assets/javascripts/components/welcome/welcome.js
+++ b/app/assets/javascripts/components/welcome/welcome.js
@@ -32,7 +32,7 @@ export default class Welcome extends Component {
       })
   }
 
-  loadAdvertisementsBySeasonsFromServer(season_id) {
+  loadAdvertisementsBySeasonsFromServer() {
     fetch(origin + 'api/advertisements')
       .then((res) => res.json())
       .then((res) => {
@@ -48,7 +48,7 @@ export default class Welcome extends Component {
       <div className='welcomeComponent'>
         <h1>{'放送中のアニメ'}</h1>
         <div className='col-md-9'>
-          <AnimeList handleDisplayAdvertisements={this.handleDisplayAdvertisements} />
+          <AnimeList onDisplayAdvertisements={this.handleDisplayAdvertisements} />
         </div>
         <div className='col-md-3'>
           {this.state.advertisements.length > 0 ? (

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -16,6 +16,16 @@
   clear: both;
 }
 
+.label .glyphicon {
+  padding-right: 0px;
+}
+
+.menu-title {
+  text-align: left;
+  padding: 10px 15px;
+  background-color: rgba($blue, 0.2);
+}
+
 .no-image {
   font-size: 12px;
   font-weight: bold;

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -16,7 +16,7 @@
   clear: both;
 }
 
-.label .glyphicon {
+.label .glyphicon-refresh {
   padding-right: 0px;
 }
 

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -36,6 +36,11 @@ span.link, a.link, .link {
   color: $blue-dark;
 }
 
+.label.link {
+  cursor: pointer;
+  color: #fff;
+}
+
 .right-icon {
   padding-left: 10px;
 }

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -68,19 +68,12 @@
 }
 
 .advertisementsComponent {
-  .refresh-field {
-    position: absolute;
-    bottom: 20px;
-    right: 20px;
-  }
-  .glyphicon-refresh {
-    font-size: 18px;
-  }
+  text-align: center;
 }
 
 .advertisementComponent {
-  padding: 10px 25px;
-  float: left;
+  display: inline-block;
+  padding: 20px 10px;
 }
 
 // == 管理画面：アニメ ==

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -73,7 +73,7 @@
 
 .advertisementComponent {
   display: inline-block;
-  padding: 20px 10px;
+  padding: 5px 10px 20px 10px;
 }
 
 // == 管理画面：アニメ ==

--- a/app/controllers/api/advertisements_controller.rb
+++ b/app/controllers/api/advertisements_controller.rb
@@ -4,12 +4,17 @@ class Api::AdvertisementsController < Api::BaseController
   before_action :set_season, only: %i[index]
 
   def index
-    @advertisements = @season.welcome_advertisements
+    @advertisements =
+      if @season
+        @season.anime_advertisements
+      else
+        Anime.airing_advertisements(Time.zone.today)
+      end
   end
 
   private
 
   def set_season
-    @season = Season.find(params[:season_id])
+    @season = Season.find(params[:season_id]) if params[:season_id]
   end
 end

--- a/app/models/anime.rb
+++ b/app/models/anime.rb
@@ -29,8 +29,6 @@ class Anime < ApplicationRecord
     Advertisement.where(anime_id: Anime.airing_ids(date)).sample(2)
   end
 
-  private
-
   def self.airing_ids(date)
     Season.airing(date).pluck(:anime_id).uniq
   end

--- a/app/models/anime.rb
+++ b/app/models/anime.rb
@@ -24,4 +24,14 @@ class Anime < ApplicationRecord
       end
     end
   end
+
+  def self.airing_advertisements(date)
+    Advertisement.where(anime_id: Anime.airing_ids(date)).sample(2)
+  end
+
+  private
+
+  def self.airing_ids(date)
+    Season.airing(date).pluck(:anime_id).uniq
+  end
 end

--- a/app/models/season.rb
+++ b/app/models/season.rb
@@ -17,7 +17,7 @@ class Season < ApplicationRecord
     where('start_on <= ?', date).where('end_on >= ? or end_on is null', date)
   end
 
-  def welcome_advertisements
-    Advertisement.where(id: anime.advertisements.pluck(:id).sample(5))
+  def anime_advertisements
+    Advertisement.where(id: anime.advertisements.pluck(:id).sample(2))
   end
 end

--- a/app/views/api/welcome/show.json.jbuilder
+++ b/app/views/api/welcome/show.json.jbuilder
@@ -15,9 +15,5 @@ json.seasons do
       json.advertisement_body melody.advertisement.try!(:body)
       json.info melody.decorate.info.html_safe
     end
-    json.advertisements season.welcome_advertisements do |advertisement|
-      json.id advertisement.id
-      json.body advertisement.body
-    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
   namespace :api, only: %i(index), format: 'json' do
     resource :user, only: %i(show)
     resource :session, only: %i(create)
+    resources :advertisements, only: %i(index)
     resources :seasons, only: :none do
       resources :advertisements, only: %i(index)
     end

--- a/spec/features/welcome_spec.rb
+++ b/spec/features/welcome_spec.rb
@@ -24,26 +24,42 @@ feature 'トップページ', js: true do
   end
 
   scenario '動画データがある場合動画が表示されること' do
+    expect(page).to have_no_css '.movieComponent'
     within "#season-#{season1.id}" do
       find('.show-movie-link').click
     end
     within '.movieComponent' do
       expect(page).to have_css 'iframe'
     end
+    within "#season-#{season1.id}" do
+      find('.show-movie-link').click
+    end
+    expect(page).to have_no_css '.movieComponent'
   end
 
   scenario '曲に広告データがある場合広告が表示されること' do
+    expect(page).to have_no_css '.movieComponent'
     within "#season-#{season1.id}" do
       find('.show-movie-link').click
     end
     within '.movieComponent' do
       expect(page).to have_css "a[href='https://url.com']"
     end
+    within "#season-#{season1.id}" do
+      find('.show-movie-link').click
+    end
+    expect(page).to have_no_css '.movieComponent'
   end
 
   scenario '広告一覧が表示されること' do
+    within '.advertisementComponent' do
+      expect(page).to have_css "a[href='https://url.com']"
+    end
+  end
+
+  scenario 'PRラベルクリックで、広告一覧が更新されること' do
     within "#season-#{season1.id}" do
-      find('.show-movie-link').click
+      find('.glyphicon-refresh').click
     end
     within '.advertisementComponent' do
       expect(page).to have_css "a[href='https://url.com']"

--- a/spec/requests/advertisements_spec.rb
+++ b/spec/requests/advertisements_spec.rb
@@ -38,23 +38,20 @@ describe 'GET /api/advertisements', autodoc: true do
 
   context 'ログインしていない場合' do
     it '200とデータが返ってくること' do
-      get "/api/advertisements"
+      get '/api/advertisements'
       expect(response.status).to eq 200
 
-      json = {
-        advertisements: contain_exactly(
-          {
-            id: advertisement1.id,
-            body: advertisement1.body
-          },
-          {
-            id: advertisement2.id,
-            body: advertisement2.body
-          }
-        )
+      json1 = {
+        id: advertisement1.id,
+        body: advertisement1.body
       }
-      json = JSON.parse(response.body)
-      expect(response.body).to be_json_as(json)
+      json2 = {
+        id: advertisement2.id,
+        body: advertisement2.body
+      }
+
+      json = JSON.parse(response.body, symbolize_names: true)[:advertisements]
+      expect(json).to contain_exactly(json1, json2)
     end
   end
 end

--- a/spec/requests/advertisements_spec.rb
+++ b/spec/requests/advertisements_spec.rb
@@ -9,7 +9,7 @@ describe 'GET /api/seasons/:season_id/advertisements', autodoc: true do
   let!(:advertisement2) { create(:advertisement, anime: anime) }
 
   context 'ログインしていない場合' do
-    it '401が返ってくること' do
+    it '200とデータが返ってくること' do
       get "/api/seasons/#{season.id}/advertisements"
       expect(response.status).to eq 200
 
@@ -25,6 +25,35 @@ describe 'GET /api/seasons/:season_id/advertisements', autodoc: true do
           }
         ]
       }
+      expect(response.body).to be_json_as(json)
+    end
+  end
+end
+
+describe 'GET /api/advertisements', autodoc: true do
+  let!(:anime) { create(:anime) }
+  let!(:season) { create(:season, anime: anime) }
+  let!(:advertisement1) { create(:advertisement, anime: anime) }
+  let!(:advertisement2) { create(:advertisement, anime: anime) }
+
+  context 'ログインしていない場合' do
+    it '200とデータが返ってくること' do
+      get "/api/advertisements"
+      expect(response.status).to eq 200
+
+      json = {
+        advertisements: contain_exactly(
+          {
+            id: advertisement1.id,
+            body: advertisement1.body
+          },
+          {
+            id: advertisement2.id,
+            body: advertisement2.body
+          }
+        )
+      }
+      json = JSON.parse(response.body)
       expect(response.body).to be_json_as(json)
     end
   end

--- a/spec/requests/welcome_spec.rb
+++ b/spec/requests/welcome_spec.rb
@@ -39,12 +39,6 @@ describe 'GET /api/welcome', autodoc: true do
                 "作詞: #{melody1.lyric_writer}<br />" \
                 "作曲: #{melody1.composer}<br />編曲: #{melody1.adapter}<br />"
             }
-          ],
-          advertisements: [
-            {
-              id: advertisement.id,
-              body: advertisement.body
-            }
           ]
         },
         {
@@ -68,8 +62,7 @@ describe 'GET /api/welcome', autodoc: true do
                 "作詞: #{melody2.lyric_writer}<br />" \
                 "作曲: #{melody2.composer}<br />編曲: #{melody2.adapter}<br />"
             }
-          ],
-          advertisements: []
+          ]
         }
       ]
     }


### PR DESCRIPTION
## 対応内容

- 広告をアニメごとに5個表示していましたが、右側メニュー側に2個のみ配置するように修正
- 広告に「PR」ラベルを配置し、クリックした際に右側メニューの広告2個をそのアニメに紐づくものをランダムで表示するようにしました