### PR TITLE
あらすじのカラムをstringからtextに変更

### DIFF
--- a/config/application.yml
+++ b/config/application.yml
@@ -13,7 +13,7 @@ defaults: &defaults
     expire_after: <%= 90.days.to_i %>
   anime:
     summary:
-      maximum_length: 250
+      maximum_length: 50000
     title:
       maximum_length: 250
     wiki_url:

--- a/db/migrate/20170521094439_change_type_summary_to_animes.rb
+++ b/db/migrate/20170521094439_change_type_summary_to_animes.rb
@@ -1,5 +1,9 @@
 class ChangeTypeSummaryToAnimes < ActiveRecord::Migration[5.1]
-  def change
+  def up
     change_column :animes, :summary, :text
+  end
+
+  def down
+    change_column :animes, :summary, :string
   end
 end

--- a/db/migrate/20170521094439_change_type_summary_to_animes.rb
+++ b/db/migrate/20170521094439_change_type_summary_to_animes.rb
@@ -1,0 +1,5 @@
+class ChangeTypeSummaryToAnimes < ActiveRecord::Migration[5.1]
+  def change
+    change_column :animes, :summary, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170512121827) do
+ActiveRecord::Schema.define(version: 20170521094439) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,7 +44,7 @@ ActiveRecord::Schema.define(version: 20170512121827) do
 
   create_table "animes", id: :serial, force: :cascade do |t|
     t.string "title", null: false
-    t.string "summary", default: "", null: false
+    t.text "summary", default: "", null: false
     t.string "wiki_url"
     t.string "picture"
     t.datetime "created_at", null: false

--- a/spec/models/anime_spec.rb
+++ b/spec/models/anime_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Anime, type: :model do
   describe 'バリデーション' do
     it { is_expected.to validate_presence_of(:title) }
     it { is_expected.to validate_length_of(:title).is_at_most(250) }
-    it { is_expected.to validate_length_of(:summary).is_at_most(50000) }
+    it { is_expected.to validate_length_of(:summary).is_at_most(50_000) }
     it { is_expected.to validate_length_of(:wiki_url).is_at_most(250) }
   end
 

--- a/spec/models/anime_spec.rb
+++ b/spec/models/anime_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Anime, type: :model do
   describe 'バリデーション' do
     it { is_expected.to validate_presence_of(:title) }
     it { is_expected.to validate_length_of(:title).is_at_most(250) }
-    it { is_expected.to validate_length_of(:summary).is_at_most(250) }
+    it { is_expected.to validate_length_of(:summary).is_at_most(50000) }
     it { is_expected.to validate_length_of(:wiki_url).is_at_most(250) }
   end
 


### PR DESCRIPTION
## 対応内容

あらすじのカラムをstringからtextに変更しました

## 対応理由

あらすじが255文字では足りなかったため
