### PR TITLE
管理画面のアニメシーズンの並び順を作成順に修正

### DIFF
--- a/app/controllers/api/admin/seasons_controller.rb
+++ b/app/controllers/api/admin/seasons_controller.rb
@@ -5,7 +5,7 @@ class Api::Admin::SeasonsController < Api::Admin::BaseController
   before_action :set_season, only: %i[update show destroy]
 
   def index
-    @seasons = @anime.seasons.order(phase: :desc)
+    @seasons = @anime.seasons.order(created_at: :desc, id: :desc)
   end
 
   def show; end

--- a/app/models/anime.rb
+++ b/app/models/anime.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 class Anime < ApplicationRecord
-  has_many :seasons, -> { order(created_at: :desc, id: :desc) },
-           dependent: :destroy
+  has_many :seasons, dependent: :destroy
   has_many :melodies, dependent: :destroy
   has_many :appearances, dependent: :destroy
   has_many :advertisements, dependent: :destroy


### PR DESCRIPTION
## 対応内容

管理画面のシーズンの並び順が`phase`になっていなかったため、そのまま作成順として正しい記載にした
