### PR TITLE
広告の画像にタグを追加＆表示

### DIFF
--- a/app/assets/javascripts/components/admin/animes/detail/advertisements/_admin_advertisement_form.js
+++ b/app/assets/javascripts/components/admin/animes/detail/advertisements/_admin_advertisement_form.js
@@ -42,7 +42,7 @@ export default class AdminAdvertisementForm extends Component {
       <div className='adminAdvertisementFormComponent'>
         <form className='form' onSubmit={this.handleClickSubmitButton}>
           <div className='form-group'>
-            <input className='form-control tag-name' placeholder='タグ名' ref='tag_name' type='text' />
+            <input className='form-control tag-name' id='tag_name' placeholder='タグ名' ref='tag_name' type='text' />
           </div>
           <div className='form-group body'>
             <textarea autoFocus className='form-control' cols='120' defaultValue={(this.props.advertisement || {}).body} disabled={this.state.loadingForm} id='body' placeholder='htmlタグ' ref='body' rows='4' />

--- a/app/assets/javascripts/components/admin/animes/detail/advertisements/_admin_advertisement_form.js
+++ b/app/assets/javascripts/components/admin/animes/detail/advertisements/_admin_advertisement_form.js
@@ -21,8 +21,7 @@ export default class AdminAdvertisementForm extends Component {
 
   handleClickSubmitButton() {
     this.setState({loadingForm: true})
-    const body = this.refs.body.value
-    this.props.onSubmit(body)
+    this.props.onSubmit(this.refs.tag_name.value, this.refs.body.value)
   }
 
   handleTimeout() {
@@ -41,7 +40,10 @@ export default class AdminAdvertisementForm extends Component {
   render() {
     return (
       <div className='adminAdvertisementFormComponent'>
-        <form className='form-inline' onSubmit={this.handleClickSubmitButton}>
+        <form className='form' onSubmit={this.handleClickSubmitButton}>
+          <div className='form-group'>
+            <input className='form-control tag-name' placeholder='タグ名' ref='tag_name' type='text' />
+          </div>
           <div className='form-group body'>
             <textarea autoFocus className='form-control' cols='120' defaultValue={(this.props.advertisement || {}).body} disabled={this.state.loadingForm} id='body' placeholder='htmlタグ' ref='body' rows='4' />
           </div>

--- a/app/assets/javascripts/components/admin/animes/detail/advertisements/_admin_anime_advertisement.js
+++ b/app/assets/javascripts/components/admin/animes/detail/advertisements/_admin_anime_advertisement.js
@@ -46,6 +46,7 @@ export default class AdminAnimeAdvertisement extends Component {
   render() {
     return (
       <div className='adminAnimeAdvertisementComponent media' id={'advertisement-' + this.props.advertisement.id}>
+        <span className='label label-default' id='tag-name'>{this.props.advertisement.tag_name}</span>
         <div className='body' dangerouslySetInnerHTML={{__html: this.props.advertisement.body}} />
         <span className='glyphicon glyphicon-trash link pull-right' onClick={this.handleClickTrashIcon} />
         <DestroyModal handleCancel={this.onClickCancelButton} handleDestroy={this.onClickDeleteButton} showModal={this.state.showModal} />

--- a/app/assets/javascripts/components/admin/animes/detail/advertisements/_admin_anime_advertisement_new_field.js
+++ b/app/assets/javascripts/components/admin/animes/detail/advertisements/_admin_anime_advertisement_new_field.js
@@ -30,9 +30,10 @@ export default class AdminAnimeAdvertisementNewField extends Component {
     this.setState({message: ''})
   }
 
-  handleClickSubmitButton(body) {
+  handleClickSubmitButton(tag_name, body) {
     const params = { advertisement: {
       anime_id: this.props.anime_id,
+      tag_name: tag_name,
       body: body
     }}
     this.postAdvertisementAgainstServer(params)

--- a/app/assets/javascripts/components/menu/_advertisement.js
+++ b/app/assets/javascripts/components/menu/_advertisement.js
@@ -4,6 +4,7 @@ export default class Advertisement extends Component {
   render () {
     return (
       <div className='advertisementComponent' id={'advertisement-' + this.props.advertisement.id}>
+        <span className='label label-default' id='tag-name'>{this.props.advertisement.tag_name}</span>
         <span dangerouslySetInnerHTML={{__html: this.props.advertisement.body}} />
       </div>
     )

--- a/app/assets/javascripts/components/welcome/_movie.js
+++ b/app/assets/javascripts/components/welcome/_movie.js
@@ -7,7 +7,7 @@ export default class Movie extends Component {
         <span className='pull-left' dangerouslySetInnerHTML={{__html: this.props.youtube}} />
         {this.props.advertisement_body ? (
           <span className='cd pull-left'>
-            <span className='label label-default'>{'CD'}</span>
+            <span className='label label-default' id='tag-name'>{'CD'}</span>
             <span dangerouslySetInnerHTML={{__html: this.props.advertisement_body}} />
           </span>
         ) : (

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -20,6 +20,11 @@
   padding-right: 0px;
 }
 
+.label#tag-name {
+  position: absolute;
+  background-color: rgba(#000, 0.7);
+}
+
 .menu-title {
   text-align: left;
   padding: 10px 15px;

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -58,10 +58,6 @@
 
 .movieComponent {
   padding: 10px 0px;
-  .label {
-    position: absolute;
-    background-color: rgba(#000, 0.7);
-  }
   span.cd {
     padding-left: 5px;
   }
@@ -165,6 +161,12 @@
 
   .summary {
     min-height: 85px;
+  }
+}
+
+.adminAnimeAdvertisementComponent {
+  .label#tag-name {
+    left: 10px;
   }
 }
 

--- a/app/controllers/api/admin/advertisements_controller.rb
+++ b/app/controllers/api/admin/advertisements_controller.rb
@@ -39,6 +39,6 @@ class Api::Admin::AdvertisementsController < Api::Admin::BaseController
 
   def advertisement_params
     params.require(:advertisement)
-          .permit(:anime_id, :actor_id, :season_id, :body)
+          .permit(:anime_id, :actor_id, :season_id, :tag_name, :body)
   end
 end

--- a/app/views/api/admin/advertisements/index.json.jbuilder
+++ b/app/views/api/admin/advertisements/index.json.jbuilder
@@ -7,5 +7,6 @@ json.advertisements do
     json.season_id advertisement.season_id
     json.season_phase advertisement.season.try!(:phase)
     json.body advertisement.body.html_safe
+    json.tag_name advertisement.tag_name
   end
 end

--- a/app/views/api/advertisements/index.json.jbuilder
+++ b/app/views/api/advertisements/index.json.jbuilder
@@ -4,5 +4,6 @@ json.advertisements do
   json.array! @advertisements do |advertisement|
     json.id advertisement.id
     json.body advertisement.body.html_safe
+    json.tag_name advertisement.tag_name
   end
 end

--- a/db/migrate/20170521152942_add_tag_name_to_advertisements.rb
+++ b/db/migrate/20170521152942_add_tag_name_to_advertisements.rb
@@ -1,0 +1,5 @@
+class AddTagNameToAdvertisements < ActiveRecord::Migration[5.1]
+  def change
+    add_column :advertisements, :tag_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170521125016) do
+ActiveRecord::Schema.define(version: 20170521152942) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -36,6 +36,7 @@ ActiveRecord::Schema.define(version: 20170521125016) do
     t.datetime "updated_at", null: false
     t.integer "season_id"
     t.bigint "melody_id"
+    t.string "tag_name"
     t.index ["actor_id"], name: "index_advertisements_on_actor_id"
     t.index ["anime_id"], name: "index_advertisements_on_anime_id"
     t.index ["melody_id"], name: "index_advertisements_on_melody_id"

--- a/spec/factories/advertisements.rb
+++ b/spec/factories/advertisements.rb
@@ -3,6 +3,7 @@
 FactoryGirl.define do
   factory :advertisement do
     anime
+    tag_name { %w[CD DVD Novels Comics].sample }
     trait :belongs_to_actor do
       anime_id { nil }
       actor

--- a/spec/features/admin/animes/advertisements_spec.rb
+++ b/spec/features/admin/animes/advertisements_spec.rb
@@ -20,6 +20,8 @@ feature '管理画面：アニメ詳細：広告', js: true do
 
       within '.adminAnimeAdvertisementsComponent' do
         expect(page).to have_css "a[href='https://url.com']"
+        expect(page).to have_content advertisement1.tag_name
+        expect(page).to have_content advertisement2.tag_name
       end
     end
 
@@ -36,13 +38,16 @@ feature '管理画面：アニメ詳細：広告', js: true do
         find('.btn-danger').click
       end
       expect(page).to have_no_css "#advertisement-#{advertisement1.id}"
+      expect(page).to have_no_content advertisement1.tag_name
       expect(page).to have_css "#advertisement-#{advertisement2.id}"
+      expect(page).to have_content advertisement2.tag_name
     end
   end
 
   scenario 'アニメの広告を登録できること' do
     within '.adminAnimeAdvertisementNewFieldComponent' do
       find('.btn-primary').click
+      fill_in 'tag_name', with: '広告のタグ名'
       fill_in 'body', with: "<a href='https://example.com'>URL</a>"
       find('.btn-danger').click
     end
@@ -50,6 +55,7 @@ feature '管理画面：アニメ詳細：広告', js: true do
     within '.adminAnimeAdvertisementsComponent' do
       expect(page).to have_content 'URL'
       expect(page).to have_css "a[href='https://example.com']"
+      expect(page).to have_content '広告のタグ名'
     end
   end
 end

--- a/spec/features/welcome_spec.rb
+++ b/spec/features/welcome_spec.rb
@@ -65,6 +65,7 @@ feature 'トップページ', js: true do
   scenario '広告一覧が表示されること' do
     within '.advertisementComponent' do
       expect(page).to have_css "a[href='https://url.com']"
+      expect(page).to have_content advertisement.tag_name
     end
   end
 
@@ -74,6 +75,7 @@ feature 'トップページ', js: true do
     end
     within '.advertisementComponent' do
       expect(page).to have_css "a[href='https://url.com']"
+      expect(page).to have_content advertisement.tag_name
     end
   end
 end

--- a/spec/requests/admin/advertisements_spec.rb
+++ b/spec/requests/admin/advertisements_spec.rb
@@ -30,14 +30,16 @@ describe 'GET /api/admin/animes/:anime_id/advertisements', autodoc: true do
             anime_id: advertisement1.anime_id,
             season_id: advertisement1.season_id,
             season_phase: nil,
-            body: advertisement1.body
+            body: advertisement1.body,
+            tag_name: advertisement1.tag_name
           },
           {
             id: advertisement2.id,
             anime_id: advertisement2.anime_id,
             season_id: advertisement2.season_id,
             season_phase: nil,
-            body: advertisement2.body
+            body: advertisement2.body,
+            tag_name: advertisement2.tag_name
           }
         ]
       }

--- a/spec/requests/advertisements_spec.rb
+++ b/spec/requests/advertisements_spec.rb
@@ -17,11 +17,13 @@ describe 'GET /api/seasons/:season_id/advertisements', autodoc: true do
         advertisements: [
           {
             id: advertisement1.id,
-            body: advertisement1.body
+            body: advertisement1.body,
+            tag_name: advertisement1.tag_name
           },
           {
             id: advertisement2.id,
-            body: advertisement2.body
+            body: advertisement2.body,
+            tag_name: advertisement2.tag_name
           }
         ]
       }
@@ -43,11 +45,13 @@ describe 'GET /api/advertisements', autodoc: true do
 
       json1 = {
         id: advertisement1.id,
-        body: advertisement1.body
+        body: advertisement1.body,
+        tag_name: advertisement1.tag_name
       }
       json2 = {
         id: advertisement2.id,
-        body: advertisement2.body
+        body: advertisement2.body,
+        tag_name: advertisement1.tag_name
       }
 
       json = JSON.parse(response.body, symbolize_names: true)[:advertisements]

--- a/spec/requests/advertisements_spec.rb
+++ b/spec/requests/advertisements_spec.rb
@@ -51,7 +51,7 @@ describe 'GET /api/advertisements', autodoc: true do
       json2 = {
         id: advertisement2.id,
         body: advertisement2.body,
-        tag_name: advertisement1.tag_name
+        tag_name: advertisement2.tag_name
       }
 
       json = JSON.parse(response.body, symbolize_names: true)[:advertisements]


### PR DESCRIPTION
## 対応内容

- 広告にタグを追加できるようにしました
- タグを表示しました
  - トップページ右側メニュー
  - 管理画面のアニメ詳細画面
