### PR TITLE
WikiのURLのカラムの上限を250文字から50000文字に変更

### DIFF
--- a/config/application.yml
+++ b/config/application.yml
@@ -17,7 +17,7 @@ defaults: &defaults
     title:
       maximum_length: 250
     wiki_url:
-      maximum_length: 250
+      maximum_length: 50000
   season:
     name:
       maximum_length: 250

--- a/db/migrate/20170521182508_change_type_wiki_url_to_animes.rb
+++ b/db/migrate/20170521182508_change_type_wiki_url_to_animes.rb
@@ -1,0 +1,9 @@
+class ChangeTypeWikiUrlToAnimes < ActiveRecord::Migration[5.1]
+  def up
+    change_column :animes, :wiki_url, :text
+  end
+
+  def down
+    change_column :animes, :wiki_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170521152942) do
+ActiveRecord::Schema.define(version: 20170521182508) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,7 +46,7 @@ ActiveRecord::Schema.define(version: 20170521152942) do
   create_table "animes", id: :serial, force: :cascade do |t|
     t.string "title", null: false
     t.text "summary", default: "", null: false
-    t.string "wiki_url"
+    t.text "wiki_url"
     t.string "picture"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/models/anime_spec.rb
+++ b/spec/models/anime_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Anime, type: :model do
     it { is_expected.to validate_presence_of(:title) }
     it { is_expected.to validate_length_of(:title).is_at_most(250) }
     it { is_expected.to validate_length_of(:summary).is_at_most(50_000) }
-    it { is_expected.to validate_length_of(:wiki_url).is_at_most(250) }
+    it { is_expected.to validate_length_of(:wiki_url).is_at_most(50_000) }
   end
 
   describe 'airing?' do


### PR DESCRIPTION
## 対応内容

WikiのURLのカラムの上限を250文字から50000文字に変更しました