### PR TITLE
アニメのサムネイルがない場合、トップページの画像領域をなしにする

### DIFF
--- a/app/assets/javascripts/__tests__/welcome/_anime.test.js
+++ b/app/assets/javascripts/__tests__/welcome/_anime.test.js
@@ -31,9 +31,6 @@ describe('AnimeComponent', () => {
               </span>
             </h2>
             <div>
-              <div className='thumbnail'>
-                <img alt={'アニメタイトル'} className='img-rounded' src={undefined} />
-              </div>
               <p className='summary'>
                  <div dangerouslySetInnerHTML={{ __html: 'アニメサマリ' }} />
               </p>

--- a/app/assets/javascripts/components/welcome/_anime.js
+++ b/app/assets/javascripts/components/welcome/_anime.js
@@ -26,9 +26,13 @@ export default class Anime extends Component {
               )}
             </h2>
             <div>
-              <div className='thumbnail'>
-                <img alt={this.props.season.anime.title} className='img-rounded' src={this.props.season.thumbnail} />
-              </div>
+              {this.props.season.anime.thumbnail ? (
+                <div className='thumbnail'>
+                  <img alt={this.props.season.anime.title} className='img-rounded' src={this.props.season.thumbnail} />
+                </div>
+              ) : (
+                null
+              )}
               <p className='summary'>
                 <div dangerouslySetInnerHTML={{ __html: this.props.season.anime.summary.replace(/\r?\n/g, '<br>') }} />
               </p>


### PR DESCRIPTION
## 対応内容

アニメのサムネイルがない場合、トップページの画像領域をなしにしました