### PR TITLE
管理画面で、「放送中」ラベルが表示されないアニメがある

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -85,6 +85,9 @@
     font-weight: bold;
     padding-bottom: 8px;
   }
+  .wiki-url {
+    word-break: break-all;
+  }
 }
 
 .adminAnimeThumbnailComponent {
@@ -137,6 +140,7 @@
     padding: 20px;
     .wiki-url {
       margin-left: 3px;
+      word-break: break-all;
     }
     .summary {
       margin-top: -3px;


### PR DESCRIPTION
## 対応内容

WikiのURLが長すぎた場合に、表示領域を超えて「放送中」ラベルが表示されなくなっていました。
WikiのURLが折り返して表示されるようにしました。