### PR TITLE
CircleCIで動作するnodeのバージョンを7.5.0から7.8.0にアップグレード

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
   ruby:
     version: 2.4.1
   node:
-    version: 7.5.0
+    version: 7.8.0
 
 general:
   artifacts:


### PR DESCRIPTION
## 対応内容

CircleCIで動作するnodeのバージョンを7.5.0から7.8.0にアップグレードしました