### PR TITLE
管理画面、アニメの広告の削除でテストが不安定になっている問題を修正

### DIFF
--- a/spec/features/admin/animes/advertisements_spec.rb
+++ b/spec/features/admin/animes/advertisements_spec.rb
@@ -38,7 +38,6 @@ feature '管理画面：アニメ詳細：広告', js: true do
         find('.btn-danger').click
       end
       expect(page).to have_no_css "#advertisement-#{advertisement1.id}"
-      expect(page).to have_no_content advertisement1.tag_name
       expect(page).to have_css "#advertisement-#{advertisement2.id}"
       expect(page).to have_content advertisement2.tag_name
     end


### PR DESCRIPTION
## 対応内容

以下のテストで不安定になっていた問題の原因の１行を削除することで解消しました。

`管理画面：アニメ詳細：広告 アニメに広告が登録されていた場合 アニメの広告を削除できること`

## 事象

テストが成功したり失敗したり。