### PR TITLE
Simplecovのレポートの設定を変更

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,7 +33,14 @@ Capybara.register_driver :selenium do |app|
 end
 
 ActiveRecord::Migration.maintain_test_schema!
-SimpleCov.start 'rails'
+SimpleCov.start do
+  add_group 'Models', 'app/models'
+  add_group 'Controllers', 'app/controllers'
+  add_group 'Helpers', 'app/helpers'
+  add_group 'Libraries', 'lib'
+  add_group 'Decorators', 'app/decorators'
+  add_group 'Uploaders', 'app/uploaders'
+end
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|


### PR DESCRIPTION
## 対応内容

Simplecovのレポートの設定を変更しました

## 対応理由

利用しない`Channels`などを排除し、必要な`Decorators`等をグループに追加するため
