### PR TITLE
CI上で発生していたeslintのwarningを解消

### DIFF
--- a/app/assets/javascripts/components/admin/animes/detail/advertisements/_admin_anime_advertisements.js
+++ b/app/assets/javascripts/components/admin/animes/detail/advertisements/_admin_anime_advertisements.js
@@ -34,11 +34,11 @@ export default class AdminAnimeAdvertisements extends Component {
       <div className='adminAnimeAdvertisementsComponent'>
         <AdminAnimeAdvertisementNewField anime_id={this.props.anime_id} handleLoadAdvertisements={this.loadAdvertisementsFromServer} />
         <ul className='advertisements'>
-        {this.state.advertisements.map((advertisement) =>
+        {this.state.advertisements.map((advertisement) => (
           <li key={advertisement.id}>
             <AdminAnimeAdvertisement advertisement={advertisement} handleLoadAdvertisements={this.loadAdvertisementsFromServer} />
           </li>
-        )}
+        ))}
         </ul>
       </div>
     )

--- a/app/assets/javascripts/components/admin/animes/list/_admin_anime_row.js
+++ b/app/assets/javascripts/components/admin/animes/list/_admin_anime_row.js
@@ -71,18 +71,18 @@ export default class AdminAnimeRow extends Component {
             )}
           </h4>
           <ul className='seasons'>
-            {this.props.anime.seasons.map((season) =>
+            {this.props.anime.seasons.map((season) => (
               <li key={season.id}>{season.anime_title}
                 <ul className='melodies'>
-                  {season.melodies.map((melody) =>
+                  {season.melodies.map((melody) => (
                     <li key={melody.id}><label className='label label-primary'>
                       <span className='glyphicon glyphicon-music' />
                       {melody.title}
                     </label></li>
-                  )}
+                  ))}
                 </ul>
               </li>
-            )}
+            ))}
           </ul>
           <div className='wiki-url'>
             <a href={this.props.anime.wiki_url} target='_blank'>{this.props.anime.wiki_url}</a>


### PR DESCRIPTION
## 対応内容

CI上で発生していたeslintのwarningを解消しました

## 対応理由

以下のwarningが発生していたため

```
/home/ubuntu/anime-music/app/assets/javascripts/components/admin/animes/detail/advertisements/_admin_anime_advertisements.js
  38:11  warning  Missing parentheses around multilines JSX  react/jsx-wrap-multilines

/home/ubuntu/anime-music/app/assets/javascripts/components/admin/animes/list/_admin_anime_row.js
  75:15  warning  Missing parentheses around multilines JSX  react/jsx-wrap-multilines
  78:21  warning  Missing parentheses around multilines JSX  react/jsx-wrap-multilines
```

## 事象

## 再現方法

## 気になること
