### PR TITLE
シーズン名としてアニメタイトルの前と後に表示

### DIFF
--- a/app/assets/javascripts/__tests__/admin/animes/detail/_admin_anime_seasons.test.js
+++ b/app/assets/javascripts/__tests__/admin/animes/detail/_admin_anime_seasons.test.js
@@ -19,14 +19,14 @@ describe('AdminAnimeSeasonsComponent', () => {
     const component = shallow(
       <AdminAnimeSeasons anime_id='1' />
     )
-    component.setState({seasons: [season1, season2]})
+    component.setState({anime_title: 'アニメタイトル', seasons: [season1, season2]})
 
     let actualElement = component.single(reactElementToJSXString)
     let expectedElement = (
       <div className='adminAnimeSeasonsComponent'>
-        <AdminAnimeSeasonNewField anime_id='1' handleLoadSeasons={jest.fn()} />
-        <AdminAnimeSeason handleLoad={jest.fn()} key={1} season={season1} />
-        <AdminAnimeSeason handleLoad={jest.fn()} key={2} season={season2} />
+        <AdminAnimeSeasonNewField anime_id='1' anime_title={'アニメタイトル'} handleLoadSeasons={jest.fn()} />
+        <AdminAnimeSeason anime_title={'アニメタイトル'} handleLoad={jest.fn()} key={1} season={season1} />
+        <AdminAnimeSeason anime_title={'アニメタイトル'} handleLoad={jest.fn()} key={2} season={season2} />
       </div>
     )
     expect(actualElement).toEqualJSX(expectedElement)

--- a/app/assets/javascripts/components/admin/animes/detail/seasons/_admin_anime_season.js
+++ b/app/assets/javascripts/components/admin/animes/detail/seasons/_admin_anime_season.js
@@ -43,6 +43,7 @@ export default class AdminAnimeSeason extends Component {
       season: {
         disabled: this.refs.form.refs.disabled.checked,
         phase: this.refs.form.refs.phase.value,
+        previous_name: this.refs.form.refs.previous_name.value,
         behind_name: this.refs.form.refs.behind_name.value,
         start_on: this.refs.form.refs.start_on.value,
         end_on: this.refs.form.refs.end_on.value

--- a/app/assets/javascripts/components/admin/animes/detail/seasons/_admin_anime_season.js
+++ b/app/assets/javascripts/components/admin/animes/detail/seasons/_admin_anime_season.js
@@ -123,7 +123,7 @@ export default class AdminAnimeSeason extends Component {
   render() {
     let editing_jsx = (
       <div className='media-body editing-body edit-form-field'>
-        <AdminAnimeSeasonForm anime_id={this.props.season.anime_id} onClose={this.handleClickCancelButton} onSubmit={this.handleClickSubmitButton} ref='form' season={this.state.season} />
+        <AdminAnimeSeasonForm anime_id={this.props.season.anime_id} anime_title={this.props.anime_title} onClose={this.handleClickCancelButton} onSubmit={this.handleClickSubmitButton} ref='form' season={this.state.season} />
         <div className='pull-right'>
           <span className='link' onClick={this.handleClickTrashIcon}>
             <span className='glyphicon glyphicon-trash' />
@@ -135,8 +135,7 @@ export default class AdminAnimeSeason extends Component {
     let not_editing_jsx = (
       <div className='media-body not-editing-body'>
         <div className='media-heading'>
-          {'第' + this.state.season.phase + '期：'}
-          {this.state.season.name}
+          {this.props.season.anime_title}
         </div>
         <div className='period'>
           {this.state.season.period}
@@ -165,6 +164,7 @@ export default class AdminAnimeSeason extends Component {
 }
 
 AdminAnimeSeason.propTypes = {
+  anime_title: PropTypes.string.isRequired,
   season: PropTypes.object.isRequired,
   handleLoad: PropTypes.func.isRequired
 }

--- a/app/assets/javascripts/components/admin/animes/detail/seasons/_admin_anime_season.js
+++ b/app/assets/javascripts/components/admin/animes/detail/seasons/_admin_anime_season.js
@@ -43,7 +43,7 @@ export default class AdminAnimeSeason extends Component {
       season: {
         disabled: this.refs.form.refs.disabled.checked,
         phase: this.refs.form.refs.phase.value,
-        name: this.refs.form.refs.name.value,
+        behind_name: this.refs.form.refs.behind_name.value,
         start_on: this.refs.form.refs.start_on.value,
         end_on: this.refs.form.refs.end_on.value
       }
@@ -135,7 +135,7 @@ export default class AdminAnimeSeason extends Component {
     let not_editing_jsx = (
       <div className='media-body not-editing-body'>
         <div className='media-heading'>
-          {this.props.season.anime_title}
+          {this.state.season.anime_title}
         </div>
         <div className='period'>
           {this.state.season.period}

--- a/app/assets/javascripts/components/admin/animes/detail/seasons/_admin_anime_season_form.js
+++ b/app/assets/javascripts/components/admin/animes/detail/seasons/_admin_anime_season_form.js
@@ -9,6 +9,7 @@ export default class AdminAnimeSeasonForm extends Component {
       unsaved_start_on: '',
       unsaved_end_on: '',
       unsaved_phase: '',
+      unsaved_previous_name: '',
       unsaved_behind_name: '',
       unsaved_disabled: (this.props.season || {}).disabled || false,
       message_type: 'danger',
@@ -19,6 +20,7 @@ export default class AdminAnimeSeasonForm extends Component {
     this.handleChangeStartOn = this.handleChangeStartOn.bind(this)
     this.handleChangeEndOn = this.handleChangeEndOn.bind(this)
     this.handleChangePhase = this.handleChangePhase.bind(this)
+    this.handleChangePreviousName = this.handleChangePreviousName.bind(this)
     this.handleChangeBehindName = this.handleChangeBehindName.bind(this)
     this.handleChangeDisabled = this.handleChangeDisabled.bind(this)
     this.handleTimeout = this.handleTimeout.bind(this)
@@ -44,6 +46,10 @@ export default class AdminAnimeSeasonForm extends Component {
 
   handleChangePhase(e) {
     this.setState({unsaved_phase: e.target.value})
+  }
+
+  handleChangePreviousName(e) {
+    this.setState({unsaved_previous_name: e.target.value})
   }
 
   handleChangeBehindName(e) {
@@ -81,6 +87,7 @@ export default class AdminAnimeSeasonForm extends Component {
             </div>
             <div className='col-sm-10'>
               <div className='form-group season-anime-title'>
+                <input autoFocus className='form-control' defaultValue={(this.props.season || {}).previous_name} disabled={this.state.loadingForm} id='season-previous-name' name='previous_name' onChange={this.handleChangePreviousName} ref='previous_name' type='text' />
                 <span>{this.props.anime_title}</span>
                 <input autoFocus className='form-control' defaultValue={(this.props.season || {}).behind_name} disabled={this.state.loadingForm} id='season-behind-name' name='behind_name' onChange={this.handleChangeBehindName} ref='behind_name' type='text' />
               </div>

--- a/app/assets/javascripts/components/admin/animes/detail/seasons/_admin_anime_season_form.js
+++ b/app/assets/javascripts/components/admin/animes/detail/seasons/_admin_anime_season_form.js
@@ -9,7 +9,7 @@ export default class AdminAnimeSeasonForm extends Component {
       unsaved_start_on: '',
       unsaved_end_on: '',
       unsaved_phase: '',
-      unsaved_name: '',
+      unsaved_behind_name: '',
       unsaved_disabled: (this.props.season || {}).disabled || false,
       message_type: 'danger',
       message: ''
@@ -19,7 +19,7 @@ export default class AdminAnimeSeasonForm extends Component {
     this.handleChangeStartOn = this.handleChangeStartOn.bind(this)
     this.handleChangeEndOn = this.handleChangeEndOn.bind(this)
     this.handleChangePhase = this.handleChangePhase.bind(this)
-    this.handleChangeName = this.handleChangeName.bind(this)
+    this.handleChangeBehindName = this.handleChangeBehindName.bind(this)
     this.handleChangeDisabled = this.handleChangeDisabled.bind(this)
     this.handleTimeout = this.handleTimeout.bind(this)
     this.updateFailed = this.updateFailed.bind(this)
@@ -46,8 +46,8 @@ export default class AdminAnimeSeasonForm extends Component {
     this.setState({unsaved_phase: e.target.value})
   }
 
-  handleChangeName(e) {
-    this.setState({unsaved_name: e.target.value})
+  handleChangeBehindName(e) {
+    this.setState({unsaved_behind_name: e.target.value})
   }
 
   handleChangeDisabled() {
@@ -82,7 +82,7 @@ export default class AdminAnimeSeasonForm extends Component {
             <div className='col-sm-10'>
               <div className='form-group season-anime-title'>
                 <span>{this.props.anime_title}</span>
-                <input autoFocus className='form-control' defaultValue={(this.props.season || {}).name} disabled={this.state.loadingForm} id='season-behind-name' name='name' onChange={this.handleChangeName} ref='name' type='text' />
+                <input autoFocus className='form-control' defaultValue={(this.props.season || {}).behind_name} disabled={this.state.loadingForm} id='season-behind-name' name='behind_name' onChange={this.handleChangeBehindName} ref='behind_name' type='text' />
               </div>
             </div>
             <div className='form-group'>

--- a/app/assets/javascripts/components/admin/animes/detail/seasons/_admin_anime_season_form.js
+++ b/app/assets/javascripts/components/admin/animes/detail/seasons/_admin_anime_season_form.js
@@ -80,8 +80,9 @@ export default class AdminAnimeSeasonForm extends Component {
               </div>
             </div>
             <div className='col-sm-10'>
-              <div className='form-group name'>
-                <input autoFocus className='form-control' defaultValue={(this.props.season || {}).name} disabled={this.state.loadingForm} id='name' name='name' onChange={this.handleChangeName} placeholder='シーズン名' ref='name' type='text' />
+              <div className='form-group season-anime-title'>
+                <span>{this.props.anime_title}</span>
+                <input autoFocus className='form-control' defaultValue={(this.props.season || {}).name} disabled={this.state.loadingForm} id='season-behind-name' name='name' onChange={this.handleChangeName} ref='name' type='text' />
               </div>
             </div>
             <div className='form-group'>
@@ -118,6 +119,7 @@ export default class AdminAnimeSeasonForm extends Component {
 }
 
 AdminAnimeSeasonForm.propTypes = {
+  anime_title: PropTypes.string.isRequired,
   season: PropTypes.object,
   onClose: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired

--- a/app/assets/javascripts/components/admin/animes/detail/seasons/_admin_anime_season_new_field.js
+++ b/app/assets/javascripts/components/admin/animes/detail/seasons/_admin_anime_season_new_field.js
@@ -39,6 +39,7 @@ export default class AdminAnimeSeasonNewField extends Component {
       start_on: this.refs.form.refs.start_on.value,
       end_on: this.refs.form.refs.end_on.value,
       phase: this.refs.form.refs.phase.value,
+      previous_name: this.refs.form.refs.previous_name.value,
       behind_name: this.refs.form.refs.behind_name.value
     }}
     this.postAnimeSeasonAgainstServer(params)
@@ -57,13 +58,17 @@ export default class AdminAnimeSeasonNewField extends Component {
       .then((res) => {
         if(res.status == '201') {
           let behind_name = ''
+          let previous_name = ''
+          if(this.refs.form.refs.previous_name.value) {
+            previous_name = '「' + this.refs.form.refs.previous_name.value + '」'
+          }
           if(this.refs.form.refs.behind_name.value) {
-            behind_name = '「' + this.refs.form.refs.behind_name.value + '」を'
+            behind_name = '「' + this.refs.form.refs.behind_name.value + '」'
           }
           this.setState({
             showForm: false,
             message_type: 'success',
-            message: behind_name + '登録しました'
+            message: previous_name + behind_name + '登録しました'
           })
           setTimeout(this.handleTimeout, 2000)
           this.props.handleLoadSeasons()

--- a/app/assets/javascripts/components/admin/animes/detail/seasons/_admin_anime_season_new_field.js
+++ b/app/assets/javascripts/components/admin/animes/detail/seasons/_admin_anime_season_new_field.js
@@ -11,7 +11,6 @@ export default class AdminAnimeSeasonNewField extends Component {
       unsaved_start_on: '',
       unsaved_end_on: '',
       unsaved_phase: '',
-      unsaved_name: '',
       message_type: 'success',
       message: ''
     }
@@ -40,7 +39,7 @@ export default class AdminAnimeSeasonNewField extends Component {
       start_on: this.refs.form.refs.start_on.value,
       end_on: this.refs.form.refs.end_on.value,
       phase: this.refs.form.refs.phase.value,
-      name: this.refs.form.refs.name.value
+      behind_name: this.refs.form.refs.behind_name.value
     }}
     this.postAnimeSeasonAgainstServer(params)
   }
@@ -57,14 +56,14 @@ export default class AdminAnimeSeasonNewField extends Component {
     })
       .then((res) => {
         if(res.status == '201') {
-          let name = ''
-          if(this.refs.form.refs.name.value) {
-            name = '「' + this.refs.form.refs.name.value + '」を'
+          let behind_name = ''
+          if(this.refs.form.refs.behind_name.value) {
+            behind_name = '「' + this.refs.form.refs.behind_name.value + '」を'
           }
           this.setState({
             showForm: false,
             message_type: 'success',
-            message: name + '登録しました'
+            message: behind_name + '登録しました'
           })
           setTimeout(this.handleTimeout, 2000)
           this.props.handleLoadSeasons()

--- a/app/assets/javascripts/components/admin/animes/detail/seasons/_admin_anime_season_new_field.js
+++ b/app/assets/javascripts/components/admin/animes/detail/seasons/_admin_anime_season_new_field.js
@@ -83,7 +83,7 @@ export default class AdminAnimeSeasonNewField extends Component {
     return (
       <div className='adminAnimeSeasonNewFieldComponent new-form-field'>
         {this.state.showForm ? (
-          <AdminAnimeSeasonForm anime_id={this.props.anime_id} onClose={this.handleClickCancelButton} onSubmit={this.handleClickSubmitButton} ref='form' />
+          <AdminAnimeSeasonForm anime_id={this.props.anime_id} anime_title={this.props.anime_title} onClose={this.handleClickCancelButton} onSubmit={this.handleClickSubmitButton} ref='form' />
           ) : (
           <AdminNewButtonField message={this.state.message} message_type={this.state.message_type} name='Anime Season' onLoadNewForm={this.handleShowNewForm} />
           )}
@@ -94,5 +94,6 @@ export default class AdminAnimeSeasonNewField extends Component {
 
 AdminAnimeSeasonNewField.propTypes = {
   anime_id: PropTypes.string.isRequired,
+  anime_title: PropTypes.string,
   handleLoadSeasons: PropTypes.func.isRequired
 }

--- a/app/assets/javascripts/components/admin/animes/detail/seasons/_admin_anime_seasons.js
+++ b/app/assets/javascripts/components/admin/animes/detail/seasons/_admin_anime_seasons.js
@@ -22,7 +22,7 @@ export default class AdminAnimeSeasons extends Component {
     })
       .then((res) => res.json())
       .then((res) => {
-        this.setState({seasons: res.seasons})
+        this.setState({anime_title: res.anime_title, seasons: res.seasons})
       })
       .catch((error) => {
         console.error(error)
@@ -32,9 +32,9 @@ export default class AdminAnimeSeasons extends Component {
   render() {
     return (
       <div className='adminAnimeSeasonsComponent'>
-        <AdminAnimeSeasonNewField anime_id={this.props.anime_id} handleLoadSeasons={this.loadSeasonsFromServer} />
+        <AdminAnimeSeasonNewField anime_id={this.props.anime_id} anime_title={this.state.anime_title} handleLoadSeasons={this.loadSeasonsFromServer} />
         {this.state.seasons.map((season) =>
-          <AdminAnimeSeason handleLoad={this.loadSeasonsFromServer} key={season.id} season={season} />
+          <AdminAnimeSeason anime_title={this.state.anime_title} handleLoad={this.loadSeasonsFromServer} key={season.id} season={season} />
         )}
       </div>
     )

--- a/app/assets/stylesheets/bootstrap_overrides.scss
+++ b/app/assets/stylesheets/bootstrap_overrides.scss
@@ -166,6 +166,19 @@ button:focus {
   width: 100px;
 }
 
+.form-control#season-behind-name, .form-control#season-previous-name {
+  display: inline-block;
+  width: 100px;
+}
+
+.form-control#season-behind-name {
+  margin-left: 5px;
+}
+
+.form-control#season-previous-name {
+  margin-left: 5px;
+}
+
 .form-control#disabled {
   display: inline-block;
   width: 100px;

--- a/app/controllers/api/admin/seasons_controller.rb
+++ b/app/controllers/api/admin/seasons_controller.rb
@@ -44,6 +44,7 @@ class Api::Admin::SeasonsController < Api::Admin::BaseController
 
   def season_params
     params.require(:season)
-          .permit(:phase, :previous_name, :behind_name, :disabled, :start_on, :end_on)
+          .permit(:phase, :disabled, :previous_name, :behind_name,
+                  :start_on, :end_on)
   end
 end

--- a/app/controllers/api/admin/seasons_controller.rb
+++ b/app/controllers/api/admin/seasons_controller.rb
@@ -43,6 +43,7 @@ class Api::Admin::SeasonsController < Api::Admin::BaseController
   end
 
   def season_params
-    params.require(:season).permit(:phase, :name, :disabled, :start_on, :end_on)
+    params.require(:season)
+          .permit(:phase, :behind_name, :disabled, :start_on, :end_on)
   end
 end

--- a/app/controllers/api/admin/seasons_controller.rb
+++ b/app/controllers/api/admin/seasons_controller.rb
@@ -44,6 +44,6 @@ class Api::Admin::SeasonsController < Api::Admin::BaseController
 
   def season_params
     params.require(:season)
-          .permit(:phase, :behind_name, :disabled, :start_on, :end_on)
+          .permit(:phase, :previous_name, :behind_name, :disabled, :start_on, :end_on)
   end
 end

--- a/app/decorators/season_decorator.rb
+++ b/app/decorators/season_decorator.rb
@@ -4,7 +4,7 @@ class SeasonDecorator < Draper::Decorator
   delegate_all
 
   def anime_title
-    title = "#{anime.title} #{name}"
+    title = "#{anime.title} #{behind_name}"
     title += " （第#{phase}期）" unless disabled
     title
   end

--- a/app/decorators/season_decorator.rb
+++ b/app/decorators/season_decorator.rb
@@ -4,7 +4,10 @@ class SeasonDecorator < Draper::Decorator
   delegate_all
 
   def anime_title
-    title = "#{anime.title} #{behind_name}"
+    title = ''
+    title += "#{previous_name} " if previous_name.present?
+    title += anime.title
+    title += " #{behind_name}" if behind_name.present?
     title += " （第#{phase}期）" unless disabled
     title
   end

--- a/app/models/season.rb
+++ b/app/models/season.rb
@@ -11,8 +11,8 @@ class Season < ApplicationRecord
             numericality: { only_integer: true,
                             greater_than_or_equal_to: 1,
                             allow_nil: true }
-  validates :behind_name,
-            length: { maximum: Settings.season.behind_name.maximum_length }
+  validates :previous_name, :behind_name,
+            length: { maximum: Settings.season.name.maximum_length }
 
   def self.airing(date)
     where('start_on <= ?', date).where('end_on >= ? or end_on is null', date)

--- a/app/models/season.rb
+++ b/app/models/season.rb
@@ -11,7 +11,8 @@ class Season < ApplicationRecord
             numericality: { only_integer: true,
                             greater_than_or_equal_to: 1,
                             allow_nil: true }
-  validates :name, length: { maximum: Settings.season.name.maximum_length }
+  validates :behind_name,
+            length: { maximum: Settings.season.behind_name.maximum_length }
 
   def self.airing(date)
     where('start_on <= ?', date).where('end_on >= ? or end_on is null', date)

--- a/app/views/api/admin/seasons/index.json.jbuilder
+++ b/app/views/api/admin/seasons/index.json.jbuilder
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
+json.anime_title @anime.title
 json.seasons do
   json.array! @seasons do |season|
     json.id season.id
     json.anime_id season.anime_id
+    json.anime_title season.decorate.anime_title
     json.phase season.phase
     json.name season.name
     json.disabled season.disabled

--- a/app/views/api/admin/seasons/index.json.jbuilder
+++ b/app/views/api/admin/seasons/index.json.jbuilder
@@ -7,6 +7,7 @@ json.seasons do
     json.anime_id season.anime_id
     json.anime_title season.decorate.anime_title
     json.phase season.phase
+    json.previous_name season.previous_name
     json.behind_name season.behind_name
     json.disabled season.disabled
     json.start_on season.start_on

--- a/app/views/api/admin/seasons/index.json.jbuilder
+++ b/app/views/api/admin/seasons/index.json.jbuilder
@@ -7,7 +7,7 @@ json.seasons do
     json.anime_id season.anime_id
     json.anime_title season.decorate.anime_title
     json.phase season.phase
-    json.name season.name
+    json.behind_name season.behind_name
     json.disabled season.disabled
     json.start_on season.start_on
     json.end_on season.end_on

--- a/app/views/api/admin/seasons/show.json.jbuilder
+++ b/app/views/api/admin/seasons/show.json.jbuilder
@@ -2,7 +2,8 @@
 
 json.id @season.id
 json.phase @season.phase
-json.name @season.name
+json.anime_title @season.decorate.anime_title
+json.behind_name @season.behind_name
 json.disabled @season.disabled
 json.start_on @season.start_on
 json.end_on @season.end_on

--- a/app/views/api/admin/seasons/show.json.jbuilder
+++ b/app/views/api/admin/seasons/show.json.jbuilder
@@ -3,6 +3,7 @@
 json.id @season.id
 json.phase @season.phase
 json.anime_title @season.decorate.anime_title
+json.previous_name @season.previous_name
 json.behind_name @season.behind_name
 json.disabled @season.disabled
 json.start_on @season.start_on

--- a/config/application.yml
+++ b/config/application.yml
@@ -19,7 +19,7 @@ defaults: &defaults
     wiki_url:
       maximum_length: 50000
   season:
-    name:
+    behind_name:
       maximum_length: 250
   user:
     email:

--- a/config/application.yml
+++ b/config/application.yml
@@ -19,7 +19,7 @@ defaults: &defaults
     wiki_url:
       maximum_length: 50000
   season:
-    behind_name:
+    name:
       maximum_length: 250
   user:
     email:

--- a/db/migrate/20170528140226_rename_name_column_to_seasons.rb
+++ b/db/migrate/20170528140226_rename_name_column_to_seasons.rb
@@ -1,0 +1,5 @@
+class RenameNameColumnToSeasons < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :seasons, :name, :behind_name
+  end
+end

--- a/db/migrate/20170528140546_add_previous_name_to_seasons.rb
+++ b/db/migrate/20170528140546_add_previous_name_to_seasons.rb
@@ -1,0 +1,5 @@
+class AddPreviousNameToSeasons < ActiveRecord::Migration[5.1]
+  def change
+    add_column :seasons, :previous_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170528140226) do
+ActiveRecord::Schema.define(version: 20170528140546) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -99,6 +99,7 @@ ActiveRecord::Schema.define(version: 20170528140226) do
     t.datetime "updated_at", null: false
     t.integer "phase", default: 0
     t.boolean "disabled", default: false, null: false
+    t.string "previous_name"
   end
 
   create_table "singers", id: :serial, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170525171831) do
+ActiveRecord::Schema.define(version: 20170528140226) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -92,7 +92,7 @@ ActiveRecord::Schema.define(version: 20170525171831) do
 
   create_table "seasons", id: :serial, force: :cascade do |t|
     t.integer "anime_id", null: false
-    t.string "name"
+    t.string "behind_name"
     t.date "start_on"
     t.date "end_on"
     t.datetime "created_at", null: false

--- a/lib/sample_generator.rb
+++ b/lib/sample_generator.rb
@@ -17,7 +17,7 @@ module SampleGenerator
   def create_melody1
     singer1 = FactoryGirl.create(:singer, name: '喜多修平')
     season1 = FactoryGirl.create(
-      :season, anime: @anime, name: '',
+      :season, anime: @anime, behind_name: '',
                start_on: '2008-07-08', end_on: '2008-09-30'
     )
 
@@ -31,7 +31,7 @@ module SampleGenerator
   def create_melody2
     singer2 = FactoryGirl.create(:singer, name: 'Aimer')
     season5 = FactoryGirl.create(
-      :season, anime: @anime, name: '伍', start_on: '2016-10-04'
+      :season, anime: @anime, behind_name: '伍', start_on: '2016-10-04'
     )
 
     FactoryGirl.create(

--- a/spec/decorators/season_decorator_spec.rb
+++ b/spec/decorators/season_decorator_spec.rb
@@ -5,18 +5,30 @@ require 'rails_helper'
 RSpec.describe SeasonDecorator, type: :decorator do
   describe '#anime_title' do
     let!(:disabled) { false }
-    let!(:season) { create(:season, phase: 2, disabled: disabled).decorate }
+    let(:previous_name) { '続' }
+    let(:behind_name) { 'シーズン2' }
+    let!(:season) do
+      create(:season, previous_name: previous_name, behind_name: behind_name, phase: 2, disabled: disabled).decorate
+    end
     subject { season.anime_title }
 
     context 'disabledがfalseの場合' do
-      it do
-        is_expected.to eq "#{season.anime.title} #{season.behind_name} （第2期）"
-      end
+      it { is_expected.to eq "続 #{season.anime.title} シーズン2 （第2期）" }
     end
 
     context 'disabledがtrueの場合' do
       let(:disabled) { true }
-      it { is_expected.to eq "#{season.anime.title} #{season.behind_name}" }
+      it { is_expected.to eq "続 #{season.anime.title} シーズン2" }
+    end
+
+    context 'previousのデータがない場合' do
+      let(:previous_name) { '' }
+      it { is_expected.to eq "#{season.anime.title} シーズン2 （第2期）" }
+    end
+
+    context 'behindのデータがない場合' do
+      let(:behind_name) { '' }
+      it { is_expected.to eq "続 #{season.anime.title} （第2期）" }
     end
   end
 

--- a/spec/decorators/season_decorator_spec.rb
+++ b/spec/decorators/season_decorator_spec.rb
@@ -9,7 +9,9 @@ RSpec.describe SeasonDecorator, type: :decorator do
     subject { season.anime_title }
 
     context 'disabledがfalseの場合' do
-      it { is_expected.to eq "#{season.anime.title} #{season.behind_name} （第2期）" }
+      it do
+        is_expected.to eq "#{season.anime.title} #{season.behind_name} （第2期）"
+      end
     end
 
     context 'disabledがtrueの場合' do

--- a/spec/decorators/season_decorator_spec.rb
+++ b/spec/decorators/season_decorator_spec.rb
@@ -9,12 +9,12 @@ RSpec.describe SeasonDecorator, type: :decorator do
     subject { season.anime_title }
 
     context 'disabledがfalseの場合' do
-      it { is_expected.to eq "#{season.anime.title} #{season.name} （第2期）" }
+      it { is_expected.to eq "#{season.anime.title} #{season.behind_name} （第2期）" }
     end
 
     context 'disabledがtrueの場合' do
       let(:disabled) { true }
-      it { is_expected.to eq "#{season.anime.title} #{season.name}" }
+      it { is_expected.to eq "#{season.anime.title} #{season.behind_name}" }
     end
   end
 

--- a/spec/decorators/season_decorator_spec.rb
+++ b/spec/decorators/season_decorator_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe SeasonDecorator, type: :decorator do
     let(:previous_name) { '続' }
     let(:behind_name) { 'シーズン2' }
     let!(:season) do
-      create(:season, previous_name: previous_name, behind_name: behind_name, phase: 2, disabled: disabled).decorate
+      create(:season, previous_name: previous_name, behind_name: behind_name,
+                      phase: 2, disabled: disabled).decorate
     end
     subject { season.anime_title }
 

--- a/spec/factories/seasons.rb
+++ b/spec/factories/seasons.rb
@@ -4,6 +4,7 @@ FactoryGirl.define do
   factory :season do
     anime
     sequence(:phase) { |n| n }
+    sequence(:previous_name) { |n| "続#{n}" }
     sequence(:behind_name) { |n| "シーズン名#{n}" }
     start_on { Time.zone.today - 10.days }
     end_on { [Time.zone.today, nil].sample }

--- a/spec/factories/seasons.rb
+++ b/spec/factories/seasons.rb
@@ -4,7 +4,7 @@ FactoryGirl.define do
   factory :season do
     anime
     sequence(:phase) { |n| n }
-    sequence(:name) { |n| "シーズン名#{n}" }
+    sequence(:behind_name) { |n| "シーズン名#{n}" }
     start_on { Time.zone.today - 10.days }
     end_on { [Time.zone.today, nil].sample }
   end

--- a/spec/features/admin/animes/seasons_spec.rb
+++ b/spec/features/admin/animes/seasons_spec.rb
@@ -22,8 +22,10 @@ feature '管理画面：シーズン', js: true do
 
       within '.adminAnimeSeasonsComponent' do
         expect(page).to have_content '第' + season1.phase.to_s + '期'
+        expect(page).to have_content season1.previous_name
         expect(page).to have_content season1.behind_name
         expect(page).to have_no_content '第' + season2.phase.to_s + '期'
+        expect(page).to have_content season2.previous_name
         expect(page).to have_content season2.behind_name
         expect(page).not_to have_content season3.behind_name
       end

--- a/spec/features/admin/animes/seasons_spec.rb
+++ b/spec/features/admin/animes/seasons_spec.rb
@@ -38,12 +38,13 @@ feature '管理画面：シーズン', js: true do
       fill_in 'start_on', with: 3.months.ago.to_date
       fill_in 'end_on', with: 1.month.ago.to_date
       fill_in 'phase', with: '1'
+      fill_in 'previous_name', with: '続'
       fill_in 'behind_name', with: '新しいシーズン名'
       check 'disabled'
       find('.btn-danger').click
     end
 
-    expect(page).to have_content '新しいシーズン名'
+    expect(page).to have_content '続 ' + anime1.title + ' 新しいシーズン名'
     expect(anime1.seasons.count).to eq 1
     expect(anime1.seasons.last.disabled).to be_truthy
   end
@@ -68,10 +69,12 @@ feature '管理画面：シーズン', js: true do
         fill_in 'start_on', with: 3.months.ago.to_date
         fill_in 'end_on', with: 1.month.ago.to_date
         fill_in 'phase', with: '1'
+        fill_in 'previous_name', with: '編集した先頭シーズン名'
         fill_in 'behind_name', with: '編集したシーズン名'
         find('.btn-danger').click
 
         expect(page).not_to have_content season1.behind_name
+        expect(page).to have_content '編集した先頭シーズン名'
         expect(page).to have_content '編集したシーズン名'
       end
     end

--- a/spec/features/admin/animes/seasons_spec.rb
+++ b/spec/features/admin/animes/seasons_spec.rb
@@ -22,10 +22,10 @@ feature '管理画面：シーズン', js: true do
 
       within '.adminAnimeSeasonsComponent' do
         expect(page).to have_content '第' + season1.phase.to_s + '期'
-        expect(page).to have_content season1.name
-        expect(page).to have_content '第' + season2.phase.to_s + '期'
-        expect(page).to have_content season2.name
-        expect(page).not_to have_content season3.name
+        expect(page).to have_content season1.behind_name
+        expect(page).to have_no_content '第' + season2.phase.to_s + '期'
+        expect(page).to have_content season2.behind_name
+        expect(page).not_to have_content season3.behind_name
       end
     end
   end
@@ -36,7 +36,7 @@ feature '管理画面：シーズン', js: true do
       fill_in 'start_on', with: 3.months.ago.to_date
       fill_in 'end_on', with: 1.month.ago.to_date
       fill_in 'phase', with: '1'
-      fill_in 'name', with: '新しいシーズン名'
+      fill_in 'behind_name', with: '新しいシーズン名'
       check 'disabled'
       find('.btn-danger').click
     end
@@ -60,16 +60,16 @@ feature '管理画面：シーズン', js: true do
       find("#season-#{season1.id}").hover
 
       within "#season-#{season1.id}" do
-        expect(page).to have_content season1.name
+        expect(page).to have_content season1.behind_name
         find('.glyphicon-pencil').click
 
         fill_in 'start_on', with: 3.months.ago.to_date
         fill_in 'end_on', with: 1.month.ago.to_date
         fill_in 'phase', with: '1'
-        fill_in 'name', with: '編集したシーズン名'
+        fill_in 'behind_name', with: '編集したシーズン名'
         find('.btn-danger').click
 
-        expect(page).not_to have_content season1.name
+        expect(page).not_to have_content season1.behind_name
         expect(page).to have_content '編集したシーズン名'
       end
     end
@@ -77,16 +77,16 @@ feature '管理画面：シーズン', js: true do
     scenario 'シーズン一覧から対象のシーズンを削除できること' do
       find("#season-#{season2.id}").hover
       within "#season-#{season2.id}" do
-        expect(page).to have_content season2.name
+        expect(page).to have_content season2.behind_name
         find('.glyphicon-pencil').click
         find('.glyphicon-trash').click
       end
       within '.modal-footer' do
         find('.btn-danger').click
       end
-      expect(page).to have_content season1.name
-      expect(page).not_to have_content season2.name
-      expect(page).to have_content season3.name
+      expect(page).to have_content season1.behind_name
+      expect(page).not_to have_content season2.behind_name
+      expect(page).to have_content season3.behind_name
 
       expect(anime1.seasons.find_by(id: season2.id)).to be_nil
     end

--- a/spec/features/welcome_spec.rb
+++ b/spec/features/welcome_spec.rb
@@ -25,13 +25,13 @@ feature 'トップページ', js: true do
 
   scenario 'disabledがtrueの場合のみ(第n期)は非表示になること' do
     expect(page).to have_content anime1.title
-    expect(page).to have_content season1.name
+    expect(page).to have_content season1.behind_name
     expect(page).to have_content '第' + season1.phase.to_s + '期'
 
     expect(page).to have_content anime2.title
-    expect(page).to have_content season2.name
+    expect(page).to have_content season2.behind_name
     expect(page).to have_no_content '第' + season2.phase.to_s + '期'
-    expect(page).to have_content season2.name
+    expect(page).to have_content season2.behind_name
   end
 
   scenario '画像データがある場合のみ画像が表示されること' do

--- a/spec/models/season_spec.rb
+++ b/spec/models/season_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Season, type: :model do
     it { is_expected.to validate_presence_of(:phase) }
     it { is_expected.to validate_uniqueness_of(:phase).scoped_to(:anime_id) }
     it { is_expected.to validate_length_of(:behind_name).is_at_most(250) }
+    it { is_expected.to validate_length_of(:previous_name).is_at_most(250) }
   end
 
   describe '#airing' do

--- a/spec/models/season_spec.rb
+++ b/spec/models/season_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Season, type: :model do
 
     it { is_expected.to validate_presence_of(:phase) }
     it { is_expected.to validate_uniqueness_of(:phase).scoped_to(:anime_id) }
-    it { is_expected.to validate_length_of(:name).is_at_most(250) }
+    it { is_expected.to validate_length_of(:behind_name).is_at_most(250) }
   end
 
   describe '#airing' do

--- a/spec/requests/admin/seasons_spec.rb
+++ b/spec/requests/admin/seasons_spec.rb
@@ -29,6 +29,7 @@ describe 'GET /api/admin/animes/1/seasons', autodoc: true do
             anime_id: season2.anime_id,
             anime_title: season2.anime_title,
             phase: season2.phase,
+            previous_name: season2.previous_name,
             behind_name: season2.behind_name,
             disabled: season2.disabled,
             start_on: season2.start_on.strftime('%Y-%m-%d'),
@@ -40,6 +41,7 @@ describe 'GET /api/admin/animes/1/seasons', autodoc: true do
             anime_id: season1.anime_id,
             anime_title: season1.anime_title,
             phase: season1.phase,
+            previous_name: season1.previous_name,
             behind_name: season1.behind_name,
             disabled: season1.disabled,
             start_on: season1.start_on.strftime('%Y-%m-%d'),
@@ -76,6 +78,7 @@ describe 'GET /api/admin/animes/:anime_id/seasons/:id', autodoc: true do
         id: season.id,
         phase: season.phase,
         anime_title: season.decorate.anime_title,
+        previous_name: season.previous_name,
         behind_name: season.behind_name,
         disabled: season.disabled,
         start_on: season.start_on.strftime('%Y-%m-%d'),
@@ -88,14 +91,16 @@ describe 'GET /api/admin/animes/:anime_id/seasons/:id', autodoc: true do
 end
 
 describe 'POST /api/admin/animes/:anime_id/seasons', autodoc: true do
-  let!(:anime) { create(:anime) }
+  let!(:anime) { create(:anime, title: 'アニメタイトル') }
   let!(:season_phase) { 1 }
+  let!(:season_previous_name) { '続' }
   let!(:season_behind_name) { 'シーズンワン' }
   let!(:three_months_ago) { 3.months.ago.to_date }
   let!(:one_month_ago) { 1.month.ago.to_date }
   let!(:params) do
     { season: {
       phase: season_phase,
+      previous_name: season_previous_name,
       behind_name: season_behind_name,
       start_on: three_months_ago,
       end_on: one_month_ago
@@ -119,6 +124,8 @@ describe 'POST /api/admin/animes/:anime_id/seasons', autodoc: true do
         expect(response.status).to eq 201
         season = anime.seasons.last
         expect(season.phase).to eq 1
+        expect(season.decorate.anime_title).to eq "続 アニメタイトル シーズンワン （第1期）"
+        expect(season.previous_name).to eq '続'
         expect(season.behind_name).to eq 'シーズンワン'
         expect(season.start_on).to eq three_months_ago
         expect(season.end_on).to eq one_month_ago

--- a/spec/requests/admin/seasons_spec.rb
+++ b/spec/requests/admin/seasons_spec.rb
@@ -75,6 +75,7 @@ describe 'GET /api/admin/animes/:anime_id/seasons/:id', autodoc: true do
       json = {
         id: season.id,
         phase: season.phase,
+        anime_title: season.decorate.anime_title,
         behind_name: season.behind_name,
         disabled: season.disabled,
         start_on: season.start_on.strftime('%Y-%m-%d'),

--- a/spec/requests/admin/seasons_spec.rb
+++ b/spec/requests/admin/seasons_spec.rb
@@ -124,7 +124,7 @@ describe 'POST /api/admin/animes/:anime_id/seasons', autodoc: true do
         expect(response.status).to eq 201
         season = anime.seasons.last
         expect(season.phase).to eq 1
-        expect(season.decorate.anime_title).to eq "続 アニメタイトル シーズンワン （第1期）"
+        expect(season.decorate.anime_title).to eq '続 アニメタイトル シーズンワン （第1期）'
         expect(season.previous_name).to eq '続'
         expect(season.behind_name).to eq 'シーズンワン'
         expect(season.start_on).to eq three_months_ago

--- a/spec/requests/admin/seasons_spec.rb
+++ b/spec/requests/admin/seasons_spec.rb
@@ -22,10 +22,12 @@ describe 'GET /api/admin/animes/1/seasons', autodoc: true do
       expect(response.status).to eq 200
 
       json = {
+        anime_title: anime.title,
         seasons: [
           {
             id: season2.id,
             anime_id: season2.anime_id,
+            anime_title: season2.anime_title,
             phase: season2.phase,
             name: season2.name,
             disabled: season2.disabled,
@@ -36,6 +38,7 @@ describe 'GET /api/admin/animes/1/seasons', autodoc: true do
           {
             id: season1.id,
             anime_id: season1.anime_id,
+            anime_title: season1.anime_title,
             phase: season1.phase,
             name: season1.name,
             disabled: season1.disabled,

--- a/spec/requests/admin/seasons_spec.rb
+++ b/spec/requests/admin/seasons_spec.rb
@@ -29,7 +29,7 @@ describe 'GET /api/admin/animes/1/seasons', autodoc: true do
             anime_id: season2.anime_id,
             anime_title: season2.anime_title,
             phase: season2.phase,
-            name: season2.name,
+            behind_name: season2.behind_name,
             disabled: season2.disabled,
             start_on: season2.start_on.strftime('%Y-%m-%d'),
             end_on: season2.end_on.try(:strftime, '%Y-%m-%d'),
@@ -40,7 +40,7 @@ describe 'GET /api/admin/animes/1/seasons', autodoc: true do
             anime_id: season1.anime_id,
             anime_title: season1.anime_title,
             phase: season1.phase,
-            name: season1.name,
+            behind_name: season1.behind_name,
             disabled: season1.disabled,
             start_on: season1.start_on.strftime('%Y-%m-%d'),
             end_on: season1.end_on.try(:strftime, '%Y-%m-%d'),
@@ -75,7 +75,7 @@ describe 'GET /api/admin/animes/:anime_id/seasons/:id', autodoc: true do
       json = {
         id: season.id,
         phase: season.phase,
-        name: season.name,
+        behind_name: season.behind_name,
         disabled: season.disabled,
         start_on: season.start_on.strftime('%Y-%m-%d'),
         end_on: season.end_on.try(:strftime, '%Y-%m-%d'),
@@ -89,13 +89,13 @@ end
 describe 'POST /api/admin/animes/:anime_id/seasons', autodoc: true do
   let!(:anime) { create(:anime) }
   let!(:season_phase) { 1 }
-  let!(:season_name) { 'シーズンワン' }
+  let!(:season_behind_name) { 'シーズンワン' }
   let!(:three_months_ago) { 3.months.ago.to_date }
   let!(:one_month_ago) { 1.month.ago.to_date }
   let!(:params) do
     { season: {
       phase: season_phase,
-      name: season_name,
+      behind_name: season_behind_name,
       start_on: three_months_ago,
       end_on: one_month_ago
     } }
@@ -118,7 +118,7 @@ describe 'POST /api/admin/animes/:anime_id/seasons', autodoc: true do
         expect(response.status).to eq 201
         season = anime.seasons.last
         expect(season.phase).to eq 1
-        expect(season.name).to eq 'シーズンワン'
+        expect(season.behind_name).to eq 'シーズンワン'
         expect(season.start_on).to eq three_months_ago
         expect(season.end_on).to eq one_month_ago
       end


### PR DESCRIPTION
## 対応内容

シーズン名としてアニメタイトルの前と後に表示できるようにしました
