### PR TITLE
react-element-to-jsx-stringをv6.4.0にアップグレード

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "react": "~15.5.4",
     "react-addons-test-utils": "~15.5.1",
     "react-dom": "~15.5.4",
-    "react-element-to-jsx-string": "~6.3.0",
+    "react-element-to-jsx-string": "~6.4.0",
     "react-router": "~3.0.2",
     "react-test-renderer": "^15.5.4",
     "reactify": "~1.1.1",


### PR DESCRIPTION
## 対応内容

react-element-to-jsx-stringをv6.4.0にアップグレードしました
