### PR TITLE
guard-rubocop をバージョン1.3.0にアップグレード

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -284,7 +284,7 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
-    guard-rubocop (1.2.0)
+    guard-rubocop (1.3.0)
       guard (~> 2.0)
       rubocop (~> 0.20)
     i18n (0.8.4)
@@ -563,9 +563,8 @@ DEPENDENCIES
   tzinfo-data
   validates_email_format_of
 
-
 RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.15.0
+   1.15.1


### PR DESCRIPTION
## 対応内容

guard-rubocop をバージョン1.3.0にアップグレードしました