### PR TITLE
トップページのタグ名を削除

### DIFF
--- a/app/assets/javascripts/components/menu/_advertisement.js
+++ b/app/assets/javascripts/components/menu/_advertisement.js
@@ -54,7 +54,6 @@ export default class Advertisement extends Component {
         <div className='panel panel-default'>
           <p className='menu-title'>{'おすすめPR'}</p>
           <div className='advertisement'>
-            <span className='label label-default' id='tag-name'>{this.state.advertisement.tag_name}</span>
             <span dangerouslySetInnerHTML={{__html: this.state.advertisement.body}} />
           </div>
         </div>

--- a/app/views/api/advertisements/index.json.jbuilder
+++ b/app/views/api/advertisements/index.json.jbuilder
@@ -2,4 +2,3 @@
 
 json.id @advertisement.id
 json.body @advertisement.body.try(:html_safe)
-json.tag_name @advertisement.tag_name

--- a/app/views/application/_advertisement.html.slim
+++ b/app/views/application/_advertisement.html.slim
@@ -3,6 +3,5 @@
     p.menu-title
       | おすすめPR
     .advertisement
-      span.label.label-default#tag-name= advertisement.tag_name
       span= sanitize advertisement.body, tags: %w[a img]
 .clear

--- a/spec/features/welcome_spec.rb
+++ b/spec/features/welcome_spec.rb
@@ -75,7 +75,6 @@ feature 'トップページ', js: true do
   scenario '広告が表示されること' do
     within '.advertisementComponent' do
       expect(page).to have_css "a[href='https://url.com']"
-      expect(page).to have_content advertisement.tag_name
     end
   end
 
@@ -85,7 +84,6 @@ feature 'トップページ', js: true do
     end
     within '.advertisementComponent' do
       expect(page).to have_css "a[href='https://url.com']"
-      expect(page).to have_content advertisement.tag_name
     end
   end
 end

--- a/spec/requests/advertisements_spec.rb
+++ b/spec/requests/advertisements_spec.rb
@@ -13,8 +13,7 @@ describe 'GET /api/animes/:anime_id/advertisements', autodoc: true do
 
       json = {
         id: advertisement.id,
-        body: advertisement.body,
-        tag_name: advertisement.tag_name
+        body: advertisement.body
       }
       expect(response.body).to be_json_as(json)
     end
@@ -33,8 +32,7 @@ describe 'GET /api/advertisements', autodoc: true do
 
       json = {
         id: advertisement.id,
-        body: advertisement.body,
-        tag_name: advertisement.tag_name
+        body: advertisement.body
       }
       expect(response.body).to be_json_as(json)
     end


### PR DESCRIPTION
## 対応内容

トップページのタグ名を削除しました。
管理画面には残します。
