### PR TITLE
トップページの曲の画像を最初の１つのみ表示する

### DIFF
--- a/app/assets/javascripts/components/admin/animes/detail/seasons/melodies/_admin_season_melody_form.js
+++ b/app/assets/javascripts/components/admin/animes/detail/seasons/melodies/_admin_season_melody_form.js
@@ -56,11 +56,7 @@ export default class AdminSeasonMelodyForm extends Component {
         composer: this.refs.composer.value,
         adapter: this.refs.adapter.value,
         memo: this.refs.memo.value,
-        youtube: this.refs.youtube.value,
-        advertisements_attributes: [{
-          id: (this.props.melody || {}).advertisement_id,
-          body: this.refs.body.value
-        }]
+        youtube: this.refs.youtube.value
       },
     }
     this.props.onSubmit(params)
@@ -164,9 +160,6 @@ export default class AdminSeasonMelodyForm extends Component {
           </div>
           <div className='form-group youtube'>
             <textarea className='form-control' cols='80' defaultValue={(this.props.melody || {}).youtube} disabled={this.state.loadingForm} id='youtube' placeholder='Youtubeの埋め込みコード' ref='youtube' rows='4' />
-          </div>
-          <div className='form-group body'>
-            <textarea className='form-control' cols='80' defaultValue={((this.props.melody || {}).advertisements[0] || {}).body} disabled={this.state.loadingForm} id='body' placeholder='htmlタグ' ref='body' rows='4' />
           </div>
           <div className='form-group draft checkbox'>
             <label>

--- a/app/assets/javascripts/components/admin/animes/detail/seasons/melodies/_admin_season_melody_form.js
+++ b/app/assets/javascripts/components/admin/animes/detail/seasons/melodies/_admin_season_melody_form.js
@@ -57,10 +57,10 @@ export default class AdminSeasonMelodyForm extends Component {
         adapter: this.refs.adapter.value,
         memo: this.refs.memo.value,
         youtube: this.refs.youtube.value,
-        advertisement_attributes: {
+        advertisements_attributes: [{
           id: (this.props.melody || {}).advertisement_id,
           body: this.refs.body.value
-        }
+        }]
       },
     }
     this.props.onSubmit(params)
@@ -166,7 +166,7 @@ export default class AdminSeasonMelodyForm extends Component {
             <textarea className='form-control' cols='80' defaultValue={(this.props.melody || {}).youtube} disabled={this.state.loadingForm} id='youtube' placeholder='Youtubeの埋め込みコード' ref='youtube' rows='4' />
           </div>
           <div className='form-group body'>
-            <textarea className='form-control' cols='80' defaultValue={(this.props.melody || {}).advertisement_body} disabled={this.state.loadingForm} id='body' placeholder='htmlタグ' ref='body' rows='4' />
+            <textarea className='form-control' cols='80' defaultValue={((this.props.melody || {}).advertisements[0] || {}).body} disabled={this.state.loadingForm} id='body' placeholder='htmlタグ' ref='body' rows='4' />
           </div>
           <div className='form-group draft checkbox'>
             <label>

--- a/app/assets/javascripts/components/welcome/_melody.js
+++ b/app/assets/javascripts/components/welcome/_melody.js
@@ -24,8 +24,8 @@ export default class Melody extends Component {
       <tbody className='melodyComponent'>
         <tr>
           <td className='advertisement'>
-            {this.props.melody.advertisement_body ? (
-              <span dangerouslySetInnerHTML={{__html: this.props.melody.advertisement_body}} />
+            {this.props.melody.advertisements[0] ? (
+              <span dangerouslySetInnerHTML={{__html: this.props.melody.advertisements[0].body}} />
             ) : (
               <span className='circle'>
                 <span className='glyphicon glyphicon-music' />

--- a/app/controllers/api/admin/melodies_controller.rb
+++ b/app/controllers/api/admin/melodies_controller.rb
@@ -43,7 +43,6 @@ class Api::Admin::MelodiesController < Api::Admin::BaseController
   def melody_params
     params.require(:melody)
           .permit(:draft, :title, :singer_name, :kind, :youtube,
-                  :lyric_writer, :composer, :adapter, :memo,
-                  advertisements_attributes: %i[id body])
+                  :lyric_writer, :composer, :adapter, :memo)
   end
 end

--- a/app/controllers/api/admin/melodies_controller.rb
+++ b/app/controllers/api/admin/melodies_controller.rb
@@ -44,6 +44,6 @@ class Api::Admin::MelodiesController < Api::Admin::BaseController
     params.require(:melody)
           .permit(:draft, :title, :singer_name, :kind, :youtube,
                   :lyric_writer, :composer, :adapter, :memo,
-                  advertisement_attributes: %i[id body])
+                  advertisements_attributes: %i[id body])
   end
 end

--- a/app/controllers/api/welcome_controller.rb
+++ b/app/controllers/api/welcome_controller.rb
@@ -3,7 +3,7 @@
 class Api::WelcomeController < Api::BaseController
   def show
     @seasons = Season.airing(Time.zone.today)
-                     .includes(%i[anime melodies])
+                     .includes(%i[anime melodies advertisements])
                      .where('melodies.draft = ?', false)
                      .references(:melodies)
                      .order(:id)

--- a/app/models/advertisement.rb
+++ b/app/models/advertisement.rb
@@ -4,7 +4,7 @@ class Advertisement < ApplicationRecord
   belongs_to :anime, optional: true
   belongs_to :actor, optional: true
   belongs_to :season, optional: true
-  belongs_to :melody, optional: true, inverse_of: :advertisement
+  belongs_to :melody, optional: true, inverse_of: :advertisements
 
   validates :body, presence: true,
                    format: { with: /\A<"\A*"|'\A*'|\A*>\z/i }

--- a/app/models/melody.rb
+++ b/app/models/melody.rb
@@ -6,13 +6,13 @@ class Melody < ApplicationRecord
   belongs_to :anime
   belongs_to :season, optional: true
   belongs_to :singer
-  has_one :advertisement, inverse_of: :melody
+  has_many :advertisements, inverse_of: :melody
   has_many :melody_images
 
-  accepts_nested_attributes_for :advertisement,
-                                reject_if: lambda { |advertisement|
-                                             advertisement[:body].blank?
-                                           }
+  accepts_nested_attributes_for :advertisements#,
+                               # reject_if: lambda { |advertisement|
+                               #              advertisement[:body].blank?
+                               #            }
 
   validates :title, :kind, presence: true
   validates :youtube,

--- a/app/models/melody.rb
+++ b/app/models/melody.rb
@@ -9,10 +9,10 @@ class Melody < ApplicationRecord
   has_many :advertisements, inverse_of: :melody
   has_many :melody_images
 
-  accepts_nested_attributes_for :advertisements#,
-                               # reject_if: lambda { |advertisement|
-                               #              advertisement[:body].blank?
-                               #            }
+  accepts_nested_attributes_for :advertisements,
+                                reject_if: lambda { |advertisement|
+                                             advertisement[:body].blank?
+                                           }
 
   validates :title, :kind, presence: true
   validates :youtube,

--- a/app/models/melody.rb
+++ b/app/models/melody.rb
@@ -9,11 +9,6 @@ class Melody < ApplicationRecord
   has_many :advertisements, inverse_of: :melody
   has_many :melody_images
 
-  accepts_nested_attributes_for :advertisements,
-                                reject_if: lambda { |advertisement|
-                                             advertisement[:body].blank?
-                                           }
-
   validates :title, :kind, presence: true
   validates :youtube,
             format: { with: /\A<iframe "\A*"|'\A*'|\A*>\z/i, allow_blank: true }

--- a/app/models/melody/fetcher.rb
+++ b/app/models/melody/fetcher.rb
@@ -18,6 +18,6 @@ class Melody::Fetcher
   def all
     melodies = @season.melodies.order(:created_at)
     melodies = melodies.send(@kind) if valid? && @kind
-    melodies.includes(:singer)
+    melodies.includes(:singer, :advertisements)
   end
 end

--- a/app/views/api/admin/melodies/index.json.jbuilder
+++ b/app/views/api/admin/melodies/index.json.jbuilder
@@ -12,8 +12,10 @@ json.melodies do
     json.memo melody.memo
     json.kind melody.kind
     json.youtube melody.youtube.try!(:html_safe)
-    json.advertisement_id melody.advertisement.try!(:id)
-    json.advertisement_body melody.advertisement.try!(:body).try!(:html_safe)
+    json.advertisements melody.advertisements do |advertisement|
+      json.id advertisement.id
+      json.body advertisement.body
+    end
     json.draft melody.draft
     json.melody_images melody.melody_images do |image|
       json.id image.id

--- a/app/views/api/welcome/show.json.jbuilder
+++ b/app/views/api/welcome/show.json.jbuilder
@@ -15,7 +15,9 @@ json.seasons do
       json.title melody.title
       json.youtube melody.youtube.try!(:html_safe)
       json.comment melody.memo
-      json.advertisement_body melody.advertisement.try!(:body)
+      json.advertisements melody.advertisements do |advertisement|
+        json.body advertisement.body
+      end
       json.info melody.decorate.info.html_safe
     end
   end

--- a/app/views/welcome/show.html.slim
+++ b/app/views/welcome/show.html.slim
@@ -36,26 +36,6 @@
                           span.title
                             span.glyphicon.glyphicon-music
                             h2= melody.title
-                  - if melody.youtube.present? || melody.advertisement.present?
-                    div
-                      span.link
-                        span.glyphicon.glyphicon-chevron-down
-                        span.show-movie-link
-                          | 視聴する
-                      .movieComponent
-                        - if melody.youtube.present?
-                          span.movie.pull-left= sanitize melody.youtube, tags: %w[iframe]
-                        - if melody.advertisement.present?
-                          span.cd.pull-left
-                            span.label.label-default#tag-name
-                              | CD
-                            span= sanitize melody.advertisement.body, tags: %w[a img]
-                        - if melody.memo.present?
-                          span.comment.pull-left
-                            span.glyphicon.glyphicon-comment
-                            br
-                            span= melody.memo
-                        .clear
   .col-md-3
     - if @advertisement.persisted?
       = render 'advertisement', advertisement: @advertisement

--- a/app/views/welcome/show.html.slim
+++ b/app/views/welcome/show.html.slim
@@ -21,21 +21,33 @@
                   span.glyphicon.glyphicon-refresh
               - if season.melodies.size > 0
                 hr.clear
-              - season.melodies.each do |melody|
-                .melodyComponent
-                  table.table
-                    tbody
-                      tr
-                        td
-                          span.label.label-info.kind-label
-                            = melody.kind.upcase
-                        td.melody-info(rowspan='2')
-                          div= melody.decorate.info.html_safe
-                      tr
-                        td.title
-                          span.title
+              table.table
+                - season.melodies.each do |melody|
+                  tbody.melodyComponent
+                    tr
+                      td.advertisement
+                        - if melody.advertisements.first
+                          span= melody.advertisements.first.body.html_safe
+                        - else
+                          span.circle
                             span.glyphicon.glyphicon-music
-                            h2= melody.title
+                      td.title
+                        span.label.label-info.kind-label
+                          = melody.kind.upcase
+                        h2
+                          span.glyphicon.glyphicon-music
+                          = melody.title
+                      td.melody-info
+                        div= melody.decorate.info.html_safe
+                    tr
+                      td(colspan='3')
+                        - if melody.memo.present?
+                          span.comment
+                            span.glyphicon.glyphicon-comment
+                            = melody.memo.html_safe
+                        - if melody.youtube.present?
+                          span.movie= melody.youtube.html_safe
+
   .col-md-3
     - if @advertisement.persisted?
       = render 'advertisement', advertisement: @advertisement

--- a/spec/features/admin/animes/melodies_spec.rb
+++ b/spec/features/admin/animes/melodies_spec.rb
@@ -52,34 +52,6 @@ feature '管理画面：シーズン', js: true do
       end
     end
 
-    scenario '対象の曲に広告を追加できること' do
-      within "#season-#{season2.id}" do
-        within '.adminAnimeSeasonMelodiesComponent' do
-          find("#melody-#{melody.id}").hover
-          find('.glyphicon-pencil').click
-        end
-        within '.adminSeasonMelodyEditFieldComponent' do
-          find('#IN').click
-          fill_in 'title', with: '曲のタイトルを編集'
-          fill_in 'youtube', with: ''
-          fill_in 'body',
-                  with: '<a href="https://example.com" >LINK</a>'
-          find('.btn-danger').click
-        end
-        within '.adminAnimeSeasonMelodiesComponent' do
-          within "#melody-#{melody.id}" do
-            find('.glyphicon-modal-window').click
-          end
-        end
-      end
-      within '.modal-body' do
-        expect(page).to have_content 'LINK'
-      end
-      within '.modal-footer' do
-        find('.btn-default').click
-      end
-    end
-
     scenario '対象の曲が削除できること' do
       within "#season-#{season2.id}" do
         within '.adminAnimeSeasonMelodiesComponent' do

--- a/spec/models/melody_spec.rb
+++ b/spec/models/melody_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Melody, type: :model do
   it { is_expected.to belong_to(:anime) }
   it { is_expected.to belong_to(:season) }
   it { is_expected.to belong_to(:singer) }
-  it { is_expected.to have_one(:advertisement) }
+  it { is_expected.to have_many(:advertisements) }
   it { is_expected.to have_many(:melody_images) }
 
   describe 'バリデーション' do

--- a/spec/requests/admin/melodies_spec.rb
+++ b/spec/requests/admin/melodies_spec.rb
@@ -42,8 +42,12 @@ describe 'GET /api/admin/seasons/1/melodies', autodoc: true do
               memo: op_melody.memo,
               kind: op_melody.kind,
               youtube: op_melody.youtube,
-              advertisement_id: op_melody.advertisement.id,
-              advertisement_body: op_melody.advertisement.body,
+              advertisements: [
+                {
+                  id: advertisement.id,
+                  body: advertisement.body
+                }
+              ],
               draft: false,
               melody_images: []
             },
@@ -58,8 +62,7 @@ describe 'GET /api/admin/seasons/1/melodies', autodoc: true do
               memo: ed_melody.memo,
               kind: ed_melody.kind,
               youtube: ed_melody.youtube,
-              advertisement_id: nil,
-              advertisement_body: nil,
+              advertisements: [],
               draft: false,
               melody_images: [
                 id: melody_image.id,

--- a/spec/requests/welcome_spec.rb
+++ b/spec/requests/welcome_spec.rb
@@ -11,7 +11,7 @@ describe 'GET /api/welcome', autodoc: true do
   let!(:melody2) { create(:melody, season: season2) }
   let!(:melody3) { create(:melody, season: season2, draft: true) }
   let!(:advertisement) { create(:advertisement, anime: anime1) }
-  let!(:melody_advertisement) { create(:advertisement, melody: melody1) }
+  let!(:melody_advertisement) { create(:advertisement, :blongs_to_melody, melody: melody1) }
 
   it '200とアニメ一覧が返ってくること' do
     get '/api/welcome'
@@ -34,7 +34,11 @@ describe 'GET /api/welcome', autodoc: true do
               title: melody1.title,
               youtube: melody1.youtube,
               comment: melody1.memo,
-              advertisement_body: melody1.advertisement.body,
+              advertisements: [
+                {
+                  body: melody_advertisement.body
+                }
+              ],
               info: "歌: #{melody1.singer.name}<br />" \
                 "作詞: #{melody1.lyric_writer}<br />" \
                 "作曲: #{melody1.composer}<br />編曲: #{melody1.adapter}<br />"
@@ -56,7 +60,7 @@ describe 'GET /api/welcome', autodoc: true do
               title: melody2.title,
               youtube: melody2.youtube,
               comment: melody2.memo,
-              advertisement_body: nil,
+              advertisements: [],
               info: "歌: #{melody2.singer.name}<br />" \
                 "作詞: #{melody2.lyric_writer}<br />" \
                 "作曲: #{melody2.composer}<br />編曲: #{melody2.adapter}<br />"

--- a/spec/requests/welcome_spec.rb
+++ b/spec/requests/welcome_spec.rb
@@ -11,7 +11,9 @@ describe 'GET /api/welcome', autodoc: true do
   let!(:melody2) { create(:melody, season: season2) }
   let!(:melody3) { create(:melody, season: season2, draft: true) }
   let!(:advertisement) { create(:advertisement, anime: anime1) }
-  let!(:melody_advertisement) { create(:advertisement, :blongs_to_melody, melody: melody1) }
+  let!(:melody_advertisement) do
+    create(:advertisement, :blongs_to_melody, melody: melody1)
+  end
 
   it '200とアニメ一覧が返ってくること' do
     get '/api/welcome'


### PR DESCRIPTION
## 対応内容

トップページの曲の画像を最初の１つのみ表示するようにしました
また、管理画面から広告の登録部分を削除しました。

それに伴い、曲の画像も登録できません。次のタスクとして、広告登録を追加します。