### PR TITLE
アクセス時にトークンの有効期限が切れた場合に、ログイン画面で認証エラーが出続ける

### DIFF
--- a/app/assets/javascripts/components/app.js
+++ b/app/assets/javascripts/components/app.js
@@ -40,6 +40,7 @@ export default class App extends Component {
     })
       .then((res) => {
         if(res.status == '401') {
+          localStorage.removeItem('access_token')
           browserHistory.push('/login')
         } else {
           res.json().then((json) => {

--- a/spec/features/admin/animes/melodies_spec.rb
+++ b/spec/features/admin/animes/melodies_spec.rb
@@ -143,4 +143,8 @@ feature '管理画面：シーズン', js: true do
       end
     end
   end
+
+  after do
+    logout
+  end
 end

--- a/spec/features/admin/animes/melody_images_spec.rb
+++ b/spec/features/admin/animes/melody_images_spec.rb
@@ -44,4 +44,8 @@ feature '管理画面：シーズン、曲の画像', js: true do
       end
     end
   end
+
+  after do
+    logout
+  end
 end

--- a/spec/features/admin/animes/seasons_spec.rb
+++ b/spec/features/admin/animes/seasons_spec.rb
@@ -95,6 +95,10 @@ feature '管理画面：シーズン', js: true do
 
       expect(anime1.seasons.find_by(id: season2.id)).to be_nil
     end
+
+    after do
+      logout
+    end
   end
 
   after do

--- a/spec/features/admin/animes/seasons_spec.rb
+++ b/spec/features/admin/animes/seasons_spec.rb
@@ -6,33 +6,16 @@ feature '管理画面：シーズン', js: true do
   let!(:user) { create(:user, :registered, :admin_user) }
   let!(:anime1) { create(:anime) }
   let!(:anime2) { create(:anime) }
+  let!(:season1) { create(:season, anime: anime1) }
+  let!(:season2) { create(:season, anime: anime1, disabled: true) }
+  let!(:season3) { create(:season, anime: anime2) }
 
   background do
     login(user)
     visit admin_anime_path(anime1)
   end
 
-  context 'シーズンが登録されていた場合' do
-    let!(:season1) { create(:season, anime: anime1) }
-    let!(:season2) { create(:season, anime: anime1, disabled: true) }
-    let!(:season3) { create(:season, anime: anime2) }
-
-    scenario 'アニメ詳細画面で該当アニメのシーズン一覧が表示されること' do
-      visit admin_anime_path(id: anime1.id)
-
-      within '.adminAnimeSeasonsComponent' do
-        expect(page).to have_content '第' + season1.phase.to_s + '期'
-        expect(page).to have_content season1.previous_name
-        expect(page).to have_content season1.behind_name
-        expect(page).to have_no_content '第' + season2.phase.to_s + '期'
-        expect(page).to have_content season2.previous_name
-        expect(page).to have_content season2.behind_name
-        expect(page).not_to have_content season3.behind_name
-      end
-    end
-  end
-
-  scenario 'シーズンを登録できること' do
+  scenario 'シーズンを新規に登録できること' do
     within '.adminAnimeSeasonNewFieldComponent' do
       find('.adminNewButtonFieldComponent').click
       fill_in 'start_on', with: 3.months.ago.to_date
@@ -45,60 +28,56 @@ feature '管理画面：シーズン', js: true do
     end
 
     expect(page).to have_content '続 ' + anime1.title + ' 新しいシーズン名'
-    expect(anime1.seasons.count).to eq 1
+    expect(anime1.seasons.count).to eq 3
     expect(anime1.seasons.last.disabled).to be_truthy
   end
 
-  context 'シーズンが登録されていた場合' do
-    let!(:season1) { create(:season, anime: anime1) }
-    let!(:season2) { create(:season, anime: anime1) }
-    let!(:season3) { create(:season, anime: anime1) }
-
-    background do
-      login(user)
-      visit admin_anime_path(anime1)
-    end
-
-    scenario '対象のシーズンを編集できること' do
-      find("#season-#{season1.id}").hover
-
-      within "#season-#{season1.id}" do
-        expect(page).to have_content season1.behind_name
-        find('.glyphicon-pencil').click
-
-        fill_in 'start_on', with: 3.months.ago.to_date
-        fill_in 'end_on', with: 1.month.ago.to_date
-        fill_in 'phase', with: '1'
-        fill_in 'previous_name', with: '編集した先頭シーズン名'
-        fill_in 'behind_name', with: '編集したシーズン名'
-        find('.btn-danger').click
-
-        expect(page).not_to have_content season1.behind_name
-        expect(page).to have_content '編集した先頭シーズン名'
-        expect(page).to have_content '編集したシーズン名'
-      end
-    end
-
-    scenario 'シーズン一覧から対象のシーズンを削除できること' do
-      find("#season-#{season2.id}").hover
-      within "#season-#{season2.id}" do
-        expect(page).to have_content season2.behind_name
-        find('.glyphicon-pencil').click
-        find('.glyphicon-trash').click
-      end
-      within '.modal-footer' do
-        find('.btn-danger').click
-      end
+  scenario 'アニメ詳細画面で該当アニメのシーズン一覧が表示されること' do
+    within '.adminAnimeSeasonsComponent' do
+      expect(page).to have_content '第' + season1.phase.to_s + '期'
+      expect(page).to have_content season1.previous_name
       expect(page).to have_content season1.behind_name
-      expect(page).not_to have_content season2.behind_name
-      expect(page).to have_content season3.behind_name
-
-      expect(anime1.seasons.find_by(id: season2.id)).to be_nil
+      expect(page).to have_no_content '第' + season2.phase.to_s + '期'
+      expect(page).to have_content season2.previous_name
+      expect(page).to have_content season2.behind_name
+      expect(page).not_to have_content season3.behind_name
     end
+  end
 
-    after do
-      logout
+  scenario '対象のシーズンを編集できること' do
+    find("#season-#{season1.id}").hover
+
+    within "#season-#{season1.id}" do
+      expect(page).to have_content season1.behind_name
+      find('.glyphicon-pencil').click
+
+      fill_in 'start_on', with: 3.months.ago.to_date
+      fill_in 'end_on', with: 1.month.ago.to_date
+      fill_in 'phase', with: '1'
+      fill_in 'previous_name', with: '編集した先頭シーズン名'
+      fill_in 'behind_name', with: '編集したシーズン名'
+      find('.btn-danger').click
+
+      expect(page).not_to have_content season1.behind_name
+      expect(page).to have_content '編集した先頭シーズン名'
+      expect(page).to have_content '編集したシーズン名'
     end
+  end
+
+  scenario 'シーズン一覧から対象のシーズンを削除できること' do
+    find("#season-#{season2.id}").hover
+    within "#season-#{season2.id}" do
+      expect(page).to have_content season2.behind_name
+      find('.glyphicon-pencil').click
+      find('.glyphicon-trash').click
+    end
+    within '.modal-footer' do
+      find('.btn-danger').click
+    end
+    expect(page).to have_content season1.behind_name
+    expect(page).not_to have_content season2.behind_name
+
+    expect(anime1.seasons.find_by(id: season2.id)).to be_nil
   end
 
   after do


### PR DESCRIPTION
## 原因

アクセス時、`localStorage`の`access_token`があるため、ログイン認証される。
しかし、有効期限が切れているために401が返ってくる。
その度に`componentWillReceiveProps`を通ってログイン認証し、エラーが出続けた。


## 対応内容

- ログインのアクセストークンの有効期限が切れた場合に認証エラーが出続ける問題を修正しました。
  - 401が返ってきた場合は、`localStorage`の`access_token`を消すことでログイン認証を再度行わせないようにした。
- ついでに、ログインした場合はログアウトするようにテストを修正しました。
- `spec/features/admin/animes/seasons_spec.rb`テストの構成を修正しました。