### PR TITLE
Make username selectable

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -17,6 +17,7 @@
 default: &default
   adapter: postgresql
   encoding: unicode
+  username: <%= ENV['DATABASE_USERNAME'] || ENV['USER'] %>
   # For details on connection pooling, see rails configuration guide
   # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
@@ -79,7 +80,9 @@ test:
 #     url: <%= ENV['DATABASE_URL'] %>
 #
 production:
-  <<: *default
+  adapter: postgresql
+  encoding: unicode
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   database: anime_music_production
   user: <%= ENV['POSTGRESQL_USERNAME'] %>
   host: <%= ENV['POSTGRESQL_HOST'] %>


### PR DESCRIPTION
## 対応内容
データベースのユーザー名を指定出来る様にした。指定しない場合はcurrent user($USER)を参照するようにしている。

## 対応理由
config/database.ymlでユーザー名の指定が現状出来無いため、環境によってはデータベースが作成、編集出来ない

## 事象
`rake db:create`など実行するとこうなる

```
$ bundle exec rake db:create                                                                                                                                                                                         [2.4.1 (local)]
FATAL:  role "sachin21dev" does not exist
Couldn't create database for {"adapter"=>"postgresql", "encoding"=>"unicode", "pool"=>5, "database"=>"anime-music_test", "url"=>nil}
rake aborted!
ActiveRecord::NoDatabaseError: FATAL:  role "sachin21dev" does not exist
```

## 再現方法
環境によるため再現方法は特に書かないが、ぼくの環境を書いておく。

- OS: Linux sachin21dev 4.11.3-1-ARCH #1 SMP PREEMPT Sun May 28 10:40:17 CEST 2017 x86_64 GNU/Linux
- PostgreSQLの権限あるユーザーは指定されたユーザーに権限をまとめている。

## 気になること
特になし